### PR TITLE
PhysX 4.1.1.27006925

### DIFF
--- a/physx-4.1.1.27006925/README.md
+++ b/physx-4.1.1.27006925/README.md
@@ -1,0 +1,61 @@
+# NVIDIA PhysX SDK 4.1
+
+Copyright (c) 2019 NVIDIA Corporation. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ * Neither the name of NVIDIA CORPORATION nor the names of its
+   contributors may be used to endorse or promote products derived
+   from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+## Introduction
+
+Welcome to the NVIDIA PhysX SDK source code repository. This depot includes the PhysX SDK and the Kapla Demo application.
+
+The NVIDIA PhysX SDK is a scalable multi-platform physics solution supporting a wide range of devices, from smartphones to high-end multicore CPUs and GPUs. PhysX is already integrated into some of the most popular game engines, including Unreal Engine, and Unity3D. [PhysX SDK on developer.nvidia.com](https://developer.nvidia.com/physx-sdk).
+
+## Documentation
+
+Please see [Release Notes](http://gameworksdocs.nvidia.com/PhysX/4.1/release_notes.html) for updates pertaining to the latest version.
+
+The full set of documentation can also be found in the repository under physx/documentation or online at http://gameworksdocs.nvidia.com/simulation.html 
+
+Platform specific information can be found here:
+* [Microsoft Windows](http://gameworksdocs.nvidia.com/PhysX/4.1/documentation/platformreadme/windows/readme_windows.html)
+* [Linux](http://gameworksdocs.nvidia.com/PhysX/4.1/documentation/platformreadme/linux/readme_linux.html)
+* [Google Android ARM](http://gameworksdocs.nvidia.com/PhysX/4.1/documentation/platformreadme/android/readme_android.html)
+* [Apple macOS](http://gameworksdocs.nvidia.com/PhysX/4.1/documentation/platformreadme/mac/readme_mac.html)
+* [Apple iOS](http://gameworksdocs.nvidia.com/PhysX/4.1/documentation/platformreadme/ios/readme_ios.html)
+ 
+
+## Quick Start Instructions
+
+Requirements:
+* Python 2.7.6 or later
+* CMake 3.12 or later
+
+To begin, clone this repository onto your local drive.  Then change directory to physx/, run ./generate_projects.[bat|sh] and follow on-screen prompts.  This will let you select a platform specific solution to build.  You can then open the generated solution file with your IDE and kick off one or more configuration builds.
+
+To build and run the Kapla Demo see [kaplademo/README.md](kaplademo/README.md).
+
+## Acknowledgements
+
+This depot contains external third party open source software copyright their respective owners.  See [kaplademo/README.md](kaplademo/README.md) and [externals/README.md](externals/README.md) for details.

--- a/physx-4.1.1.27006925/commit.txt
+++ b/physx-4.1.1.27006925/commit.txt
@@ -1,0 +1,1 @@
+https://github.com/NVIDIAGameWorks/PhysX @ ae80dede0546d652040ae6260a810e53e20a06fa

--- a/physx-4.1.1.27006925/release_notes.html
+++ b/physx-4.1.1.27006925/release_notes.html
@@ -1,0 +1,5157 @@
+<html><head>
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Release Notes - NVIDIA PhysX SDK 4.1</title>
+    <style type="text/css">
+        body {
+            font-family: 'Trebuchet MS', 'DIN Pro', sans-serif;
+            font-size: 90%;
+        }
+
+        h1 {
+            color: #000000;
+        }
+
+        h2, h3, h4, h5 {
+            color: #76b900;
+            margin-bottom: 0px;
+        }
+
+        ul {
+            margin-top: 5px;
+        }
+    </style>
+</head>
+
+<body>
+
+   <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 4.1.1</h1>
+    <h2 style="TEXT-ALIGN: center">August 2019</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>Support for Visual Studio 2019 has been added, cmake 3.14 is required.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>Android binary output directory name contains Android ABI string.</li>
+        </ul>
+    </ul>
+
+    <h3>Vehicles</h3>
+    <ul>
+		<li>Added:</li>
+        <ul>
+            <li>PxVehicleWheelsSimFlags and corresponding set/get 
+methods have been added to PxVehicleWheelsSimData. The flag 
+eLIMIT_SUSPENSION_EXPANSION_VELOCITY can be used to avoid suspension 
+forces being applied if the suspension can not expand fast enough to 
+push the wheel onto the ground in a simulation step. This helps to 
+reduce artifacts like the vehicle sticking to the ground if extreme 
+damping ratios are chosen.</li>
+        </ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>The PxVehicleDrive::setToRestState() was not clearing 
+all cached data, which could sometimes make vehicles misbehave after 
+calls to this function.</li>
+        </ul>
+    </ul>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>Added error message when not at least four valid vertices exist after vertices cleanup.</li>
+        </ul>
+    </ul>
+
+    <h3>Serialization</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Binary serialization of kinematic rigid dynamic actors was failing unless they were part of a scene.</li>
+        </ul>
+    </ul>
+
+    <h3> Rigid body </h3>
+    <ul>
+        <li>Fixed</li>
+        <ul>
+            <li>Out of shared memory failure with GPU articulations.</li>
+            <li>Inconsistent results when setting joint drive targets with GPU articulations compared to CPU articulations.</li>
+            <li>Assert when simulating a scene with &gt; 64k rigid bodies and joints.</li>
+            <li>Error in PxActor::getConnectors() method when there are multiple connector types.</li>
+            <li>Setting joint positions on articulations did not update world-space link poses and velocities.</li>
+            <li>Improved TGS articulation joint drive solver.</li>
+            <li>Improved robustness of articulation spherical joints.</li>
+            <li>Joint forces/positions/velocities set through the PxArticulationCache are correctly applied when using GPU articulations.</li>
+            <li>Fixed rare crash in MBP when the system contains out-of-bounds objects.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 4.1.0</h1>
+    <h2 style="TEXT-ALIGN: center">March 2019</h2>
+
+    <h3>Overview</h3>
+    <ul>
+        <li>Immediate mode support for reduced-coordinates articulations and the temporal Gauss Seidel solver.</li>
+        <li>GPU acceleration for reduced-coordinates articulations.</li>
+    </ul>
+
+    <h3>General</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>Added support for UWP, note that cmake 3.13.4 is required for uwp arm64.</li>
+        </ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>PhysXGpu DLLs are now standalone, so they will now work with both static and dynamic PhysX libraries.</li>
+            <li>PhysX delay loading code is disabled for the static library configuration.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>Removed PxGpuDispatcher class. Instead of querying the 
+GPU dispatcher with PxCudaContextManager::getGpuDispatcher() and 
+providing it to the PxScene with PxSceneDesc::gpuDispatcher, please 
+provide the CUDA context manager directly using 
+PxSceneDesc::cudaContextManager.</li>
+            <li>PxCreateCudaContextManager does have an additional 
+parameter PxProfilerCallback, that is required in order to get profiling
+ events from the GPU dll.</li>
+            <li>FastXml project is now compiled as OBJECT on win platforms and is linked into PhysXExtensions library.</li>
+            <li>Removed PxArticulationBase::getType(), 
+PxArticulationBase::eReducedCoordinate, 
+PxArticulationBase::eMaximumCoordinate and added 
+PxConcreteType::eARTICULATION_REDUCED_COORDINATE, 
+PxConcreteType::eARTICULATION_JOINT_REDUCED_COORDINATE.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>Immediate mode API for reduced-coordinates articulations.</li>
+            <li>Immediate mode API for the temporal Gauss Seidel (TGS) solver .</li>
+            <li>Compute dense Jacobian matrix for the reduced-coordinates articulations.</li>
+            <li>GPU acceleration for reduced-coordinates articulations with PGS solver.</li>
+            <li>GPU acceleration for reduced-coordinates articulations with TGS solver (experimental).</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>PxSimulationStatistics::nbDynamicBodies does not include
+ kinematics any longer. Instead they are covered in new 
+nbKinematicBodies counter.</li>
+        </ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed speculative CCD optimization with sleeping bodies.</li>
+            <li>Fixed the overlap termination condition in the GJK code for sphere primitive. </li>
+            <li>Fixed a bug in the face selection algorithm for paper thin box overlapped with capsule. </li>
+            <li>Fixed a contact recycling issue with PCM contact gen. </li>
+            <li>Fixed an issue with articulation when removing and adding links to the articulation. </li>
+        </ul>
+    </ul>
+
+    <h3>Serialization</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>PxSerialization::serializeCollectionToBinaryDeterministic,
+ convenience function to post-process binary output with 
+PxBinaryConverter for determinism. For achieving determinism, the 
+checked build needs to be used.</li>
+            <li>Support for binary and xml serialization for PxArticulationReducedCoordinate.</li>
+        </ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>PxBinaryConverter can now produce deterministic output, 
+independent of the runtime environment the objects have been serialized 
+in. For achieving determinism, the checked build needs to be used for 
+serializing collections.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>PX_BINARY_SERIAL_VERSION has been changed to a global 
+unique identifier string. PX_PHYSICS_VERSION is no longer part of binary
+ data versioning.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 4.0.0.25635910</h1>
+    <h2 style="TEXT-ALIGN: center">January 2019</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed issue in PxBinaryConverter::convert that could corrupt platform re-targeting of convex meshes with more than 127 vertices.</li>
+            <li>GenerateProject scripts should now also work when not called from PhysX directory.</li>
+            <li>GenerateProject script will now create correct compiler/ directory on Linux based systems.</li>
+            <li>Removed /Wall from MSVC compilers.</li>
+            <li>Fixed CMake install, added missing cudacontextmanager files.</li>
+            <li>Fixed binary serialization of actors in aggregates without serialization of the containing aggregate.</li>
+        </ul>
+        <li>Removed:</li>
+        <ul>
+            <li>CharacterKinematic API export/import macros have been removed.</li>
+        </ul>
+        <li>Added:</li>
+        <ul>
+            <li>Support for Linux samples has been added.</li>
+            <li>PxConfig.h include file will be generated during 
+generate projects script. Including this file in your project will 
+ensure that required defines (like PX_PHYSX_STATIC_LIB) are set.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>PX_FOUNDATION_API was moved to PhysX and uses PX_PHYSX_STATIC_LIB define as the rest of the SDK.</li>
+            <li>PxAssertHandler moved from PxShared to PhysX and marked as deprecated.</li>
+            <li>PxShared does use PX_SHARED_ASSERT instead of PX_ASSERT which is used just in the PhysX SDK and uses PxAssertHandler.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 4.0</h1>
+    <h2 style="TEXT-ALIGN: center">December 2018</h2>
+
+    <h3>Supported Platforms</h3>
+
+    <table cellspacing="3">
+        <tbody><tr>
+            <th width="24">
+            </th><th align="left">Runtime</th>
+            <th width="18">
+            </th><th align="left">Development</th>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Apple iOS (tested on 12.1)</td>
+            <td>
+            </td><td>Xcode (tested with 10.1)</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Apple macOS (tested on 10.13)</td>
+            <td>
+            </td><td>Xcode (tested with 10.1)</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Google Android ARM (tested with API Level 19 - KITKAT)</td>
+            <td>
+            </td><td>NDK r13b</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Linux (tested on Ubuntu 16.04), GPU acceleration: display driver and GPU supporting CUDA 10 / CUDA ARCH 3.0</td>
+            <td>
+            </td><td>Clang (tested with 3.8)</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Microsoft Windows, GPU acceleration: display driver and GPU supporting CUDA 10 / CUDA ARCH 3.0</td>
+            <td>
+            </td><td>Microsoft Visual Studio 2013, 2015, 2017</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Microsoft XBox One*</td>
+            <td>
+            </td><td></td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Nintendo Switch*</td>
+            <td>
+            </td><td></td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Sony Playstation 4*</td>
+            <td>
+            </td><td></td>
+        </tr>
+    </tbody></table>
+
+    * Console code subject to platform NDA not available on GitHub.  
+Developers licensed by respective platform owners please contact NVIDIA 
+for access.
+
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+    </blockquote>
+
+    <h3>General</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>New Temporal Gauss Seidel (TGS) solver offering a new level of simulation accuracy.</li>
+            <li>New Reduced Coordinate Articulation feature with no relative positional error and realistic actuation.</li>
+            <li>New automatic multi-broadphase (ABP) providing better out of the box performance for many use cases.</li>
+            <li>New BVH structure supporting better performance for actors with many shapes.</li>
+        </ul>
+        <li>Removed:</li>
+        <ul>
+            <li>PhysX Particle feature.</li>
+            <li>PhysX Cloth feature.</li>
+            <li>The deprecated active transforms feature has been removed. Please use active actors instead.</li>
+            <li>The deprecated multi client behavior feature has been removed.</li>
+            <li>The deprecated legacy heightfields have been removed.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>The PhysX SDK build system is now based on CMake 
+generated build configuration files. For more details, please refer to 
+the PhysX SDK 4.0 Migration Guide.</li>
+            <li>The Linux build has been changed to produce static as opposed to shared libraries. The compiler was switched from GCC to Clang.</li>
+            <li>The PxShared library contains functionality shared 
+beyond the PhysX SDK. It has been streamlined to a minimal set of 
+headers. The PxFoundation singleton has been moved back to the PhysX 
+SDK, as well as the task manager, CUDA context manager and PhysX Visual 
+Debugger (PVD) functionality.</li>
+            <li>PhysXDelayLoadHook and PhysXGpuLoadHook have been simplified, and PxFoundationDelayLoadHook has been removed.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>A new broadphase implementation has been added. See 
+PxBroadPhaseType::eABP for details. This is now the default broadphase 
+implementation.</li>
+            <li>TGS: A new rigid body solver, which can produce improved convergence compared to the default rigid body solver.</li>
+            <li>Optional torsional friction model to simulate rotational friction when there is just a single point of contact.</li>
+            <li>A flag to enable friction constraints to be processed every frame has been added</li>
+            <li>PxContactJoint added to represent contacts in inverse dynamics. Not intended for use in simulation.</li>
+            <li>A missing PxShape::getReferenceCount() function has been added.</li>
+            <li>A new flag has been added to PxMaterial to improve 
+friction accuracy. The flag is disabled by default to maintain legacy 
+behavior.</li>
+        </ul>
+        <li>Removed:</li>
+        <ul>
+            <li>PxVisualizationParameter::eDEPRECATED_BODY_JOINT_GROUPS has been removed.</li>
+            <li>PxSceneDesc::maxNbObjectsPerRegion has been removed.</li>
+            <li>PxRigidActor::createShape() has been removed. Please use
+ PxPhysics::createShape() or PxRigidActorExt::createExclusiveShape() 
+instead</li>
+            <li>The deprecated mass parameter in PxTolerancesScale has been removed.</li>
+            <li>PxSceneFlag::eDEPRECATED_TRIGGER_TRIGGER_REPORTS has been removed.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>Aggregates can now contain more than 128 actors.</li>
+            <li>Switching a kinematic object to dynamic does not 
+automatically wake up the object anymore. Explicit calls to 
+PxRigidDynamic::wakeUp() are now needed.</li>
+            <li>Switching a kinematic object to dynamic re-inserts the 
+object into the broadphase, producing PxPairFlag::eNOTIFY_TOUCH_FOUND 
+events instead of PxPairFlag::eNOTIFY_TOUCH_PERSISTS events.</li>
+            <li>PxConvexMeshGeometryFlag::eTIGHT_BOUNDS is now enabled by default for PxConvexMeshGeometry.</li>
+            <li>The default max angular velocity for rigid bodies has been changed, from 7 to 100.</li>
+
+        </ul>
+    </ul>
+
+
+    <h3>Extensions</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>PxD6Joint now supports per-axis linear limit pairs.</li>
+            <li>Added PxSphericalJoint::getSwingYAngle and PxSphericalJoint::getSwingZAngle.</li>
+            <li>Added PxD6Joint distance limit debug visualization.</li>
+            <li>Added PxD6JointCreate.h file with helper functions to setup the D6 joint in various common configurations.</li>
+            <li>Added pyramidal swing limits to the D6 joint.</li>
+        </ul>
+
+        <li>Removed:</li>
+        <ul>
+            <li>PxComputeHeightFieldPenetration has a new signature.</li>
+            <li>PxComputeMeshPenetration has been removed. Use PxComputeTriangleMeshPenetration instead.</li>
+        </ul>
+
+        <li>Changed:</li>
+        <ul>
+            <li>PxRevoluteJoint now properly supports a -PI*2 to +PI*2 
+range for its limits, and the accuracy of limits has been improved. In 
+order to use extended limit ranges, 
+PxConstraintFlag::eENABLE_EXTENDED_LIMITS must be raised on the 
+constraint.</li>
+            <li>PxD6Joint now properly supports a -PI*2 to +PI*2 range 
+for its twist limit, and the accuracy of the twist limit has been 
+improved. In order to use extended limit ranges, 
+PxConstraintFlag::eENABLE_EXTENDED_LIMITS must be raised on the 
+constraint.</li>
+            <li>The accuracy of the D6 joint swing limits has been improved.</li>
+            <li>PxDistanceJoint does now always insert constraint row, this change does increase the limit precision.</li>
+            <li>PxDistanceJoint::getDistance does not anymore return squared distance.</li>
+            <li>PxD6Joint::setDriveVelocity, PxD6Joint::setDrivePosition
+ and PxRevoluteJoint::setDriveVelocity have now additional parameter 
+autowake, which will wake the joint rigids up if true (default 
+behavior).</li>
+            <li>Joint shaders now take a bool to define whether to use extended joint limits or not.</li>
+            <li>Joint shaders must now provide the cA2w and cB2w 
+vectors, defining the world-space location of the joint anchors for both
+ bodies.</li>
+        </ul>
+
+        <li>Deprecated:</li>
+        <ul>
+            <li>PxD6Joint::getTwist() has been deprecated. Please use PxD6Joint::getTwistAngle() now.</li>
+            <li>The previous PxD6Joint::setLinearLimit() and 
+PxD6Joint::getLinearLimit() functions (supporting a single linear limit 
+value) have been deprecated. Please use PxD6Joint::setDistanceLimit() 
+and PxD6Joint::getDistanceLimit() instead. Or you can also use the new 
+PxD6Joint::setLinearLimit() and PxD6Joint::getLinearLimit() functions, 
+which now support pairs of linear limit values.</li>
+        </ul>
+    </ul>
+
+    <h3>Articulations</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>New reduced coordinate articulation implementation, 
+supporting a wider range of joint types, more accurate drive model, 
+inverse dynamics and joint torque control.</li>
+            <li>PxArticulationJoint::getParentArticulationLink and PxArticulationJoint::getChildArticulationLink has been added.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene queries</h3>
+    <ul>
+        <li>Removed:</li>
+        <ul>
+            <li>PxHitFlag::eDISTANCE has been removed.</li>
+            <li>The PxVolumeCache feature has been removed.</li>
+            <li>The PxSpatialIndex feature has been removed.</li>
+            <li>The deprecated PxSceneFlag::eSUPPRESS_EAGER_SCENE_QUERY_REFIT has been removed.</li>
+        </ul>
+    </ul>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>PxBVHStructure added, it computes and stores BVH 
+structure for given bounds. The structure can be used for actors with 
+large amount of shapes to perform scene queries actor centric rather 
+than shape centric. For more information please see guide or snippets.</li>
+        </ul>
+        <li>Removed:</li>
+        <ul>
+            <li>PxPlatform enum has been removed. PhysX supported platforms all share the same endianness</li>
+            <li>The deprecated PxCookingParams::meshCookingHint and PxCookingParams::meshSizePerformanceTradeOff parameters have been removed.</li>
+            <li>The deprecated PxGetGaussMapVertexLimitForPlatform has been removed, use PxCookingParams::gaussMapLimit instead.</li>
+            <li>The deprecated PxConvexMeshCookingType::eINFLATION_INCREMENTAL_HULL and PxCookingParams::skinWidth have been removed.</li>
+            <li>PxBVH34MidphaseDesc::numTrisPerLeaf has been renamed to PxBVH34MidphaseDesc::numPrimsPerLeaf</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.2.25354359</h1>
+    <h2 style="TEXT-ALIGN: center">December 2018</h2>
+
+    <h2>General</h2>
+    <ul>
+        <li>Changed:</li>
+        <ul>
+            <li>Changed GitHub distribution to BSD license.</li>
+        </ul>
+    </ul>
+
+    <h2>Supported Platforms</h2>
+
+    <table cellspacing="3">
+        <tbody><tr>
+            <th width="24">
+            </th><th align="left">Runtime</th>
+            <th width="18">
+            </th><th align="left">Development</th>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Apple iOS (tested on 12.1)</td>
+            <td>
+            </td><td>Xcode (tested with 10.1)</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Apple macOS (tested on 10.13)</td>
+            <td>
+            </td><td>Xcode (tested with 10.1)</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Google Android ARM (tested with API Level 16, Android 4.1 - JELLY_BEAN)</td>
+            <td>
+            </td><td>NDK r13b-win32</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Linux (tested on Ubuntu 16.04, GPU acceleration: NVIDIA Driver version R361+ and CUDA ARCH 3.0)</td>
+            <td>
+            </td><td>GCC (tested with 4.8)</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Microsoft Windows XP or later (NVIDIA Driver version R304 or later is required for GPU acceleration)</td>
+            <td>
+            </td><td>Microsoft Visual Studio 2012, 2013, 2015</td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Microsoft XBox One*</td>
+            <td>
+            </td><td></td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Nintendo Switch*</td>
+            <td>
+            </td><td></td>
+        </tr>
+        <tr>
+            <td>
+            </td><td>Sony Playstation 4*</td>
+            <td>
+            </td><td></td>
+        </tr>
+    </tbody></table>
+
+    * Console code subject to platform NDA not available on GitHub.  
+Developers licensed by respective platform owners please contact NVIDIA 
+for access.
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.2.25256367</h1>
+    <h2 style="TEXT-ALIGN: center">November 2018</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Changed:</li>
+        <ul>
+            <li>A couple of serialization write functions have been optimized.</li>
+            <li>Rtree cooking has been slightly optimized.</li>
+            <li>Renamed PxSerializer::requires to PxSerializer::requiresObjects due to an erroneous clash with C++20 keyword with apple-clang.</li>
+        </ul>
+        <li>Fixed:</li>
+        <li>Moved external vector math includes out of PhysX namespaces.</li>
+    </ul>
+    
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed an incorrect trigger behavior when a trigger was removed and inserted within the same frame.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene query</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed a bug in BVH34. Raycasts could fail on binary deserialized BVH34 triangle meshes.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.2.24990349</h1>
+    <h2 style="TEXT-ALIGN: center">September 2018</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>PxMeshQuery::getTriangle adjacency information for heightfield geometry fixed.</li>
+            <li>Removed PxSetPhysXGpuDelayLoadHook from API. Delay 
+loaded dynamically linked library names are now provided through 
+PxSetPhysXDelayLoadHook.</li>
+            <li>Fixed a source of non-determinism with GPU rigid bodies.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed a divide by zero bug when gjk is trying to 
+calculate the barycentric coordinate for two identical/nearly identical 
+points. </li>
+            <li>Fixed an incorrect mesh index reported in contact buffer when stabilization flag was used. </li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.2.24698370</h1>
+    <h2 style="TEXT-ALIGN: center">August 2018</h2>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed a crash bug when EPA's edge buffer overflow. </li>
+            <li>GPU rigid bodies fixed for Volta GPUs.</li>
+        </ul>
+        <li>Added:</li>
+        <ul>
+            <li>Aggregate broad phase now runs in parallel</li>
+        </ul>
+    </ul>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul></ul>
+        <li>Added:</li>
+        <ul>
+            <li>PxHeightField::getSample has been added.</li>
+        </ul>
+    </ul>
+
+    <h3>Character controller</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Capsule controller with a very small height could 
+degenerate to spheres (with a height of exactly zero) far away from the 
+origin, which would then triggers errors in Debug/Checked builds. This 
+has been fixed.</li>
+            <li>The triangle array growing strategy has been changed 
+again to prevent performance issues when tessellation is used. Memory 
+usage may increase in these cases.</li>
+            <li>Some internal debug visualization code has been disabled and a crash in it has been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene query</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed possible buffer overrun when PxPruningStructure was used.</li>
+            <li>Raycasts against a heightfield may have missed if a large distance was used.</li>
+            <li>Sq raycasts against heightfield or triangle mesh could return a mildly negative values, this has been fixed.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.2.24214033</h1>
+    <h2 style="TEXT-ALIGN: center">May 2018</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed clang 7 unionCast issues.</li>
+            <li>Fixed the binary meta data in PhysX_3.4/Tools/BinaryMetaData for conversion of vehicles.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Deprecated:</li>
+        <ul>
+            <li>PxSceneFlag::eENABLE_KINEMATIC_STATIC_PAIRS and 
+PxSceneDesc::eENABLE_KINEMATIC_PAIRS have been deprecated. Use the new 
+PxPairFilteringMode parameters in PxSceneDesc instead.</li>
+        </ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>A sequence of 
+shape-&gt;setFlag(PxShapeFlag::eSIMULATION_SHAPE, false) / 
+shape-&gt;setFlag(PxShapeFlag::eSIMULATION_SHAPE, true) without 
+simulation calls inbetween could produce errors in the broadphase. This 
+has been fixed.</li>
+            <li>Fixed a bug in the broadphase (SAP) that got recently 
+introduced in SDK 3.4.1.23933511. It should only have generated a few 
+false positives (more overlaps than stricly necessary).</li>
+            <li>Fixed a bug in PxShape::checkMaterialSetup.</li>
+            <li>Fixed intermittent crash with GPU rigid bodies when materials were destroyed.</li>
+            <li>Fixed bug where setting maxImpulse to 0 on CCD contact 
+modification meant contact was not reported in the frame's contact 
+reports.</li>
+        </ul>
+    </ul>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Big convex mesh serialization used together with 
+insertion callback stored incorrect memory for big convex data. This has
+ been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene query</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed a bug in extended bucket pruner, when a pruning structure was added and immediatelly released.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.1.23933511</h1>
+    <h2 style="TEXT-ALIGN: center">April 2018</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>Added snippet for deformable meshes, added section in the guide for them.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>PxTriangleMesh::refitBVH() was crashing with PxMeshPreprocessingFlag::eDISABLE_ACTIVE_EDGES_PRECOMPUTE. This has been fixed.</li>
+            <li>SQ-only shapes contained in aggregates could result in 
+crashes or memory corruption when removed from the aggregate. This has 
+been fixed.</li>
+            <li>Assert no longer fired if a dynamic body contacting a static is converted to kinematic with kinematic-static pairs enabled.</li>
+            <li>Assert reporting broad phase as being "inconsistent" could fire when using speculative CCD when sleeping objects were activated.</li>
+        </ul>
+    </ul>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Convex hull cooking could have produced hulls with vertices too far from convex hull planes, this has been fixed.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>PxCooking::createTriangleMesh does now take additional output parameter PxTriangleMeshCookingResult::Enum.</li>
+            <li>PxCooking::createConvexMesh does now take additional output parameter PxConvexMeshCookingResult::Enum.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene query</h3>
+    <ul>
+        <li>Changed:</li>
+        <ul>
+            <li>PxSceneFlag::eSUPPRESS_EAGER_SCENE_QUERY_REFIT has been 
+marked as deprecated. Was replaced with PxSceneQueryUpdateMode enum, if 
+this new enum is set the flag gets ignored.</li>
+        </ul>
+        <li>Added:</li>
+        <ul>
+            <li>PxSceneQueryUpdateMode was added to control work done during fetchResults.</li>
+            <li>PxScene::sceneQueriesUpdate, PxScene::checkQueries and 
+PxScene::fetchQueries were added to run separate scene query update, see
+ manual for more details.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.1.23584284</h1>
+    <h2 style="TEXT-ALIGN: center">February 2018</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>PhysX sometimes froze in a spinlock after certain sequences of read &amp; write locks. This has been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene queries</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Raycasts against heightfields were sometimes missing 
+hits for vertical rays were located exactly at the heightfield's 
+boundaries. This has been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Avoid edge-face collisions on boundary edges when 
+eNO_BOUNDARY_EDGES flag is raised on heightfield when using PCM and 
+unified HF collision.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.1.23472123</h1>
+    <h2 style="TEXT-ALIGN: center">January 2018</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>Visual Studio 2017 15.5.1 and newer is now supported. Samples are currently not supported with Visual Studio 2017.</li>
+        </ul>
+
+        <li>Removed:</li>
+        <ul>
+            <li>Visual Studio 2012 support is discontinued.</li>
+        </ul>
+    </ul>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Cooked mesh structures contained a mix of little-endian 
+and big-endian data (the midphase structures were always saved as 
+big-endian). This made loading of cooked files slower than necessary. 
+This has been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene queries</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Buffered moves were sometimes not properly taken into 
+account by scene queries, leading to invalid results for one frame. This
+ has been fixed.</li>
+            <li>Pruning structure failed to build when actor had more shapes. This has been fixed.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.1.23173160</h1>
+    <h2 style="TEXT-ALIGN: center">November 2017</h2>
+
+    <h3>Extensions</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>An issue with CCD sweeps against meshes that could potentially lead to the earliest impact not being detected has been fixed.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.1.23131702</h1>
+    <h2 style="TEXT-ALIGN: center">November 2017</h2>
+
+    <h3>General</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>A bug in the management of internal interaction objects has been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Extensions</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>A regression in prismatic constraint stability introduced in PhysX 3.4.1 has been fixed.</li>
+            <li>PxRevoluteJoint::getAngle(), PxD6Joint::getTwist(), 
+PxD6Joint::getSwingYAngle() and PxD6Joint::getSwingZAngle() did not 
+always return the correct angle. This problem has been fixed.</li>
+            <li>The "double cone" case of the D6 joint had errors both 
+in the debug visualization and the code dealing with limits. This has 
+been fixed.</li>
+            <li>The debug visualization of the D6 joint in the twist case did not properly color-code the angular limits. This has been fixed.</li>
+            <li>The debug visualization of distance joints has been fixed.</li>
+            <li>The debug visualization of prismatic joints has been fixed.</li>
+            <li>The debug visualization of revolute joints has been 
+fixed. It now renders active limits properly (in red when the limit is 
+active, grey otherwise).</li>
+            <li>Proper visualization flags are now passed to the 
+PxConstraintVisualize function. Previously all available flags were 
+active, even if PxVisualizationParameter::eJOINT_LOCAL_FRAMES and/or 
+PxVisualizationParameter::eJOINT_LIMITS were set to zero.</li>
+            <li>PxRevoluteJoint::getVelocity has been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene queries</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Sweep queries using the eMTD flag could generate 
+incorrect normals in sphere/sphere, sphere/capsule or capsule/capsule 
+cases, when the objects were exactly overlapping each-other. This has 
+been fixed.</li>
+            <li>Sweep convex mesh vs heightfield queries using the eMTD flag did not fill correctly returned faceIndex. This has been fixed.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.1</h1>
+    <h2 style="TEXT-ALIGN: center">September 2017</h2>
+
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+    </blockquote>
+
+    <h3>General</h3>
+    <ul>
+        <li>Deprecated:</li>
+        <ul>
+            <li>The PhysX cloth feature has been deprecated.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>The meaning of PxVisualizationParameter::eCULL_BOX has 
+changed. It is now used to visualize the current culling box, while it 
+was previously used to enable or disable the feature. Please simply use 
+PxScene::setVisualizationCullingBox() to enable the feature from now on.</li>
+            <li>PxVisualizationParameter::eBODY_JOINT_GROUPS has been deprecated.</li>
+            <li>Performance of setCMassLocalPose function has been improved.</li>
+        </ul>
+        <li>Added:</li>
+        <ul>
+            <li>PhysXGpu: Added warnings for the case when the dynamic gpu library fails to load.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>A potential crash when calling detachShape has been fixed.</li>
+            <li>Fixed assert that fired if application switched a body 
+from dynamic to kinematic, then queried kinematic target without setting
+ one. This assert only fired if the modifications overlapped simulation 
+so were buffered.</li>
+            <li>PxArticulation::getStabilizationThreshold() and 
+PxArticulation::setStabilizationThreshold() were accessing the sleep 
+threshold instead of the stabilization threshold. This has been fixed.</li>
+            <li>Fixed an internal edge bug in PCM sphere vs mesh code</li>
+            <li>Make sure sphere vs sphere and sphere vs box in PCM 
+contact gen generate contacts consistently on the second body when the 
+sphere center is contained in the other shape</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>Improved convex vs mesh contact generation when using GPU rigid bodies. Requires the mesh to be recooked.</li>
+            <li>Improved convex vs convex contact generation when using GPU rigid bodies.</li>
+            <li>Reduced memory footprint of GPU triangle meshes significantly. Requires the mesh to be recooked.</li>
+        </ul>
+        <li>Added:</li>
+        <ul>
+            <li>Support for modifying friction and restitution coefficients has been added to contact modification. </li>
+            <li>Added PxRigidBodyFlag::eENABLE_CCD_MAX_CONTACT_IMPULSE 
+to enable maxContactImpulse member of PxRigidBody to be used in CCD. 
+This is disabled by default. It is useful in some circumstances, e.g. 
+shooting a small ball through a plate glass window and triggering it to 
+break, but it can also result in behavioral artefacts so it is disabled 
+by default.</li>
+            <li>Added PxSceneDesc::solverOffsetSlop. This is defaulted 
+to a value of 0. A positive, non-zero value defines a tolerance used in 
+the solver below which a contacts' offset from the COM of the body is 
+negligible and therefore snapped to zero. This clamping occurs in a 
+space tangential to the contact or friction direction. This is aimed at 
+pool or golf simulations, where small numerical imprecision in either 
+contact points or normals can lead to balls curving slightly when there 
+are relatively high angular velocities involved.</li>
+            <li>Added PxConvexMeshGeometry::maxMargin. This allows the 
+application to tune the maximum amount by which PCM collision detection 
+will shrink convex shapes in contact generation. This shrinking approach
+ leads to some noticeable clipping around edges and vertices, but should
+ not lead to clipping with face collisions. By default, the mesh is 
+shrunk by an amount that is automatically computed based on the shape's 
+properties. This allows you to limit by how much the shape will be 
+shrunk. If the maxMargin is set to 0, then the original shape will be 
+used for collision detection. </li>
+        </ul>
+
+    </ul>
+
+    <h3>Scene queries</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>A rare invalid memory read that could lead to incorrect sweep results in case of an initial overlap has been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Serialization</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Binary serialization didn't preserve PxConstraintFlags, e.g. projection flags.</li>
+            <li>Xml serialization failed if a shape referencing a PxTriangleMesh was added to another (dependent) collection.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.0.22387197</h1>
+    <h2 style="TEXT-ALIGN: center">June 2017</h2>
+
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+    </blockquote>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed issue when PxConvexFlag::e16_BIT_INDICES was used together with PxConvexFlag::eCOMPUTE_CONVEX.</li>
+            <li>Fixed issue in convex hull cooking when postHullMerge was not executed.</li>
+            <li>Fixed crash in CCD when using bodies with 0 mass.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed behavioral differences when comparing the results 
+of a given scene to the results when simulating a subset of the islands 
+in that scene. In order for this case to be deterministic, it is 
+necessary to raise PxSceneFlag::eENABLE_ENHANCED_DETERMINISM. </li>
+        </ul>
+
+        <li>Added:</li>
+        <ul>
+            <li>Introduced maxBiasCoefficient in PxSceneDesc to be able 
+to limit the coefficient used to scale error to produce the bias used in
+ the constraint solver to correct geometric error. The default value is 
+PX_MAX_F32 and, therefore, a value of 1/dt will be used. This value can 
+be useful to reduce/remove jitter in scenes with variable or very small 
+time-steps.
+        </li></ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.0.22121272</h1>
+    <h2 style="TEXT-ALIGN: center">May</h2>
+
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+    </blockquote>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed a bug in convex vs convex PCM contact gen code. 
+There were cases in which full contact gen should have been triggered 
+but was not. </li>
+            <li>Fixed a jittering bug on both GPU/CPU codepath in PCM 
+contact gen code. This is due to the contact recycling condition not 
+considering the toleranceLength. </li>
+            <li>Fixed a bug causing simulation to behave incorrectly when greater than 65536 bodies were simulated.</li>
+        </ul>
+    </ul>
+
+    <h3>Scene queries</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>A rare crash that could happen with sphere overlap calls has been fixed.</li>
+            <li>Fixed a stack corruption in CCD contact modification callback.</li>
+            <li>Fixed a bug where external forces were not cleared correctly with PxArticulations.</li>
+        </ul>
+    </ul>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Changed:</li>
+        <ul>
+            <li>Convex hull cooking now reuses edge information, perf optimization.</li>
+            <li>PxCooking API is now const if possible.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.0.22017166</h1>
+    <h2 style="TEXT-ALIGN: center">April 2017</h2>
+
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+    </blockquote>
+
+    <h3>General</h3>
+    <ul>
+        <li>Added:</li>
+        <ul>
+            <li>PxConvexMeshGeometry::maxMargin has been added. This 
+will let the application limit how much the shape is shrunk in GJK when 
+using by PCM contact gen</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed a bug with joint breaking where sometimes joints would not break as expected.</li>
+            <li>Fix a race condition between cloth/particle/trigger interactions and the parallel filtering of rigid body interaction.</li>
+            <li>GPU rigid body feature now issues a performance warning in checked build if feature is enabled but PCM contact gen is not.</li>
+            <li>Fixed a bug with applying external force/torque to a body in buffered insertion stage.</li>
+            <li>Fixed a bug with CCD involving rotated static mesh actors.</li>
+            <li>Fixed a memory leak in CCD.</li>
+        </ul>
+        <li>Changed:</li>
+        <ul>
+            <li>Optimizations for GPU rigid body feature, including 
+reduced memory footprint and improvements to performance spikes when 
+many objects are woken in a single frame.</li>
+        </ul>
+    </ul>
+
+    <h3>Midphase</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fix Crash in BV4 code (serialization bug).</li>
+        </ul>
+    </ul>
+
+    <h3>Cooking</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fix endless loop in convex hull cooking.</li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4.0.21821222</h1>
+    <h2 style="TEXT-ALIGN: center">March 2017</h2>
+
+    <h2>Supported Platforms</h2>
+    <blockquote>
+        <h3>Runtime</h3>
+        <ul>
+            <li>Apple iOS</li>
+            <li>Apple Mac OS X</li>
+            <li>Google Android ARM (version 2.2 or later required for SDK, 2.3 or later required for snippets)</li>
+            <li>Linux (tested on Ubuntu)</li>
+            <li>Microsoft Windows XP or later (NVIDIA Driver version R304 or later is required for GPU acceleration)</li>
+            <li>Microsoft XBox One</li>
+            <li>Nintendo Switch</li>
+            <li>Sony Playstation 4</li>
+        </ul>
+        <h3>Development</h3>
+        <ul>
+            <li>Microsoft Windows XP or later</li>
+            <li>Microsoft Visual Studio 2012, 2013, 2015</li>
+            <li>Xcode 8.2</li>
+        </ul>
+    </blockquote>
+    <h2>Known Issues</h2>
+    <blockquote>
+        <ul></ul>
+    </blockquote>
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+    </blockquote>
+
+    <h3>General</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>A rare crash happening in the debug visualization code has been fixed.</li>
+        </ul>
+    </ul>
+
+    <h3>Rigid Bodies</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>Fixed a bug in PCM capsule vs plane contact gen.</li>
+            <li>A crash happening with more than 64K interactions has been fixed.</li>
+            <li>Fixed an island management issue in CCD when using multiple CCD passes.</li>
+            <li>Fixed a bug with GPU rigid bodies with non-simulation scene query-only shapes.</li>
+            <li>Fixed a bug in convex vs convex PCM contact gen code. 
+There were cases in which full contact gen should have been triggered 
+but was not. </li>
+            <li>Fixed a jittering bug on both GPU/CPU codepath in PCM 
+contact gen code. This is due to the contact recycling condition not 
+considering the toleranceLength. </li>
+        </ul>
+        <li>Added:</li>
+        <ul>
+            <li>getFrozenActors has been added to allow application queries the frozen actors</li>
+            <li>PxRigidDynamic::setKinematicSurfaceVelocity has been 
+added, permitting the user to set a persistent velocity on a kinematic 
+actor which behaves like a conveyor belt</li>
+            <li>PxSceneDesc::solverOffsetSlop added. This defines a 
+threshold distance from a body's COM under which a contact will be 
+snapped to the COM of the body inside the solver along any principal 
+component axis</li>
+        </ul>
+    </ul>
+
+    <h3>Scene queries</h3>
+    <ul>
+        <li>Fixed:</li>
+        <ul>
+            <li>A bug in the BVH34 overlap code sometimes made 
+PxMeshOverlapUtil::findOverlap assert (reporting an incorrect buffer 
+overflow). This has been fixed.</li>
+            <li>Fix a bug in the case of two primitives just touching in sweep with eMTD flag on. </li>
+        </ul>
+    </ul>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.4</h1>
+    <h2 style="TEXT-ALIGN: center">February 2017</h2>
+
+    <h2>Supported Platforms</h2>
+    <blockquote>
+        <h3>Runtime</h3>
+        <ul>
+            <li>Apple iOS</li>
+            <li>Apple Mac OS X</li>
+            <li>Google Android ARM (version 2.2 or later required for SDK, 2.3 or later required for snippets)</li>
+            <li>Linux (tested on Ubuntu)</li>
+            <li>Microsoft Windows XP or later (NVIDIA Driver version R304 or later is required for GPU acceleration)</li>
+            <li>Microsoft XBox One</li>
+            <li>Nintendo Switch</li>
+            <li>Sony Playstation 4</li>
+        </ul>
+        <h3>Development</h3>
+        <ul>
+            <li>Microsoft Windows XP or later</li>
+            <li>Microsoft Visual Studio 2012, 2013, 2015</li>
+            <li>Xcode 8.2</li>
+        </ul>
+    </blockquote>
+    <h2>Known Issues</h2>
+    <blockquote>
+        <ul></ul>
+    </blockquote>
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+        <h3>General</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>nbAggregates, nbArticulations, 
+nbDiscreteContactPairsTotal, nbDiscreteContactPairsWithCacheHits and 
+nbDiscreteContactPairsWithContacts have been added to 
+PxSimulationStatistics.</li>
+                <li>PxSceneLimits::maxNbBroadPhaseOverlaps has been added.</li>
+                <li>A new midphase has been added. See PxMeshMidPhase enum for details.</li>
+                <li>Midphase descriptor has been added. See PxMidphaseDesc for details.</li>
+                <li>PxHeightField::getTimestamp() has been added</li>
+                <li>PxCloneShape has been added to enable cloning of shapes.</li>
+                <li>acquireReference() has been added to increment the 
+reference count of shapes, materials, triangle meshes, convex meshes 
+heightfields and cloth fabrics.</li>
+                <li>The global filter shader data block can now be set through PxScene::setFilterShaderData().</li>
+                <li>PxGpuLoadHook and PxSetPhysXGpuLoadHook has been added to support loading of GPU dll with a different name than the default.</li>
+                <li>A new profile zone has been added for debug visualization.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>PxMathUtils.h has moved from include/common to include/foundation</li>
+                <li>GPU support requires SM2.x (Fermi architecture, GeForce 400 series) or later hardware. SM1.x is no longer supported.</li>
+                <li>Windows XP 64-bit and Windows Vista no longer support GPU acceleration. Windows XP 32-bit still supports GPU acceleration.</li>
+                <li>PxTaskManager::createTaskManager requires error callback and does not accept SPU task manager.</li>
+                <li>PxCreatePhysics and  PxCreateBasePhysics now take an optional pointer to an  physx::PxPvd instance.  </li>
+                <li>PxConstraintConnector::updatePvdProperties now takes an optional pointer to an physx::pvdsdk::PvdDataStream instance.</li>
+                <li>PxInitExtensions now takes an optional pointer to an physx::PxPvd instance.</li>
+                <li>Shared objects (triangle mesh, convex mesh, 
+heightfield, material, shape, cloth fabric) no longer issue an 
+eUSER_RELEASE event when their release() method is called</li>
+                <li>
+                    PxBase::isReleasable() is now a property only of the type of an object, not the object state. In particular,
+                    isReleasable() returns true for PxShape objects whose only counted reference belongs to their owning actor.
+                </li>
+                <li>PxCollection::releaseObjects() now calls release() 
+even on shapes whose only counted reference belongs to their owning 
+actor. An optional parameter releaseExclusiveShapes, which defaults to 
+true, has been added to this method to assist with common scenarios in 
+which all shapes are created with the deprecated method 
+PxRigidActor::createShape() or its replacement 
+PxRigidActorExt::createExclusiveShape()</li>
+                <li>Negative mesh scale is now supported for 
+PxTriangleMeshGeometry. Negative scale corresponds to reflection and 
+scale along the corresponding axis. In addition to reflection PhysX will
+ flip the triangle normals.</li>
+                <li>PxDelayLoadHook is now inherited from 
+PxFoundationDelayLoadHook. PxFoundation dll and PxPvdSDK dll are now 
+delay loaded inside the SDK, their names can be provided through the 
+delay load hook.</li>
+            </ul>
+            <li>Removed:</li>
+            <ul>
+                <li>Sony Playstation 3 is not supported any longer. Any related APIs have been removed.</li>
+                <li>Microsoft XBox 360 is not supported any longer. Any related APIs have been removed.</li>
+                <li>Nintendo Wii U is not supported any longer. Any related APIs have been removed.</li>
+                <li>Sony Playstation Vita is not supported any longer. Any related APIs have been removed.</li>
+                <li>Visual Studio 2010 is not supported any longer.</li>
+                <li>Microsoft Windows RT is not supported any longer.</li>
+                <li>Google Android X86 is not supported any longer.</li>
+                <li>PhysX Samples are not supported anymore except on Microsoft Windows.</li>
+                <li>Linux 32-bit no longer support GPU acceleration. Linux 64-bit still supports GPU acceleration.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxScene::setFlag() does now properly send error messages in CHECKED builds if a non-mutable scene flag gets passed in.</li>
+                <li>Fixed a bug in force threshold based contact reports, which caused events to be lost.</li>
+                <li>Fixed a bug in aggregates that led to a crash when 
+rigid bodies are added to an aggregate after removing all rigid bodies 
+from an aggregate. This only occurred with aggregates that were added to
+ the scene and with rigid bodies that had shapes attached.</li>
+                <li>Fixed a bug where non-breakable joints could break, leading to a crash. </li>
+                <li>Fixed RepX load of kinematic rigid bodies with mesh shapes.</li>
+                <li>Fixed a divide by zero bug in SIMD distanceSegmentTriangle function.</li>
+                <li>Debug visualization for compound bounds 
+(PxVisualizationParameter::eCOLLISION_COMPOUNDS) now works even when all
+ the compounds' shapes have their debug viz flag 
+(PxShapeFlag::eVISUALIZATION) disabled.</li>
+                <li>Double-buffering now works properly for the debug visualization culling box.</li>
+                <li>The default debug visualization culling box now works correctly with heightfields.</li>
+                <li>Rare crashes in PxShape::setGeometry() and PxShape::getMaterials() have been fixed.</li>
+                <li>A crash happening when doing an origin shift on a scene containing an empty aggregate has been fixed.</li>
+            </ul>
+            <li>Deprecated:</li>
+            <ul>
+                <li>PxSceneLimits::maxNbObjectsPerRegion has been deprecated. It is currently not used.</li>
+                <li>PxComputeHeightFieldPenetration has a new signature, and the old one has been deprecated</li>
+                <li>PxComputeMeshPenetration has been deprecated. Use PxComputeTriangleMeshPenetration.</li>
+                <li>The PhysX particle feature has been deprecated.</li>
+                <li>PxTolerancesScale::mass has been deprecated.  It is currently not used.</li>
+                <li>PxActorClientBehaviorFlag has been marked as deprecated and will be removed in future releases.</li>
+            </ul>
+            <li>Removed deprecated API:</li>
+            <ul>
+                <li>PxPairFlag::eCCD_LINEAR removed. Use PxPairFlag::eDETECT_CCD_CONTACT | PxPairFlag::eSOLVE_CONTACT instead.</li>
+                <li>PxPairFlag::eRESOLVE_CONTACTS removed. Use PxPairFlag::eDETECT_DISCRETE_CONTACT | PxPairFlag::eSOLVE_CONTACT instead.</li>
+                <li>PxTriangleMeshFlag::eHAS_16BIT_TRIANGLE_INDICE removed. Use PxTriangleMeshFlag::e16_BIT_INDICES instead.</li>
+                <li>PxTriangleMeshFlag::eHAS_ADJACENCY_INFO removed. Use PxTriangleMeshFlag::eADJACENCY_INFO instead.</li>
+                <li>PxTriangleMeshDesc::convexEdgeThreshold removed.</li>
+                <li>PxSceneQueryFlag renamed to PxHitFlag.</li>
+                <li>PxHitFlag::eDIRECT_SWEEP renamed to PxHitFlag::ePRECISE_SWEEP.</li>
+                <li>PxHitFlag::eIMPACT renamed to PxHitFlag::ePOSITION.</li>
+                <li>PxSceneQueryHitType renamed to PxQueryHitType.</li>
+                <li>PxSceneQueryCache renamed to PxQueryCache.</li>
+                <li>PxSceneQueryFilterFlag renamed to PxQueryFlag.</li>
+                <li>PxSceneQueryFilterFlags renamed to PxQueryFlags.</li>
+                <li>PxSceneQueryFilterData renamed to PxQueryFilterData.</li>
+                <li>PxSceneQueryFilterCallback renamed to PxQueryFilterCallback.</li>
+                <li>PxScene::raycastAll,PxScene::raycastSingle,PxScene::raycastAny replaced by PxScene::raycast.</li>
+                <li>PxScene::overlapAll,PxScene::overlapAny replaced by PxScene::overlap.</li>
+                <li>PxScene::sweepAll,PxScene::sweepSingle,PxScene::sweepAny replaced by PxScene::sweep.</li>
+                <li>PxQuat, PxTranform, PxMat33, PxMat44 createIdentity and createZero removed. Use PxIdentity, PxZero in constructor.</li>
+                <li>PxJointType::Enum, PxJoint::getType() removed. Use PxJointConcreteType instead.</li>
+                <li>PxVisualDebugger removed. Use PxPvd instead.</li>
+                <li>PxControllerFlag renamed to PxControllerCollisionFlag.</li>
+                <li>PxCCTHit renamed to PxControllerHit.</li>
+                <li>PxCCTNonWalkableMode renamed to PxControllerNonWalkableMode.</li>
+                <li>PxControllerNonWalkableMode::eFORCE_SLIDING changed to PxControllerNonWalkableMode::ePREVENT_CLIMBING_AND_FORCE_SLIDING.</li>
+                <li>PxControllerDesc::interactionMode, groupsBitmask, callback removed.</li>
+                <li>PxController::setInteraction, getInteraction, setGroupsBitmask, getGroupsBitmask removed.</li>
+                <li>PxControllerManager::createController no longer needs PxPhysics and PxScene.</li>
+                <li>PxControllerFilters::mActiveGroups replaced with PxControllerFilters::mCCTFilterCallback.</li>
+                <li>PxSerialization::createBinaryConverter(PxSerializationRegistry&amp;) changed to PxSerialization::createBinaryConverter().</li>
+                <li>PxConstraintDominance renamed to PxDominanceGroupPair.</li>
+                <li>PxScene::flush renamed to PxScene::flushSimulation.</li>
+                <li>PxClothFabric::getPhaseType removed.</li>
+                <li>PxCollection::addRequired removed.</li>
+                <li>PxRigidActor::createShape discontinued support for initial transform.</li>
+                <li>PxShape::resetFiltering removed.</li>
+                <li>PxParticleBase::resetFiltering removed.</li>
+                <li>PxSceneDesc::meshContactMargin removed.</li>
+                <li>PxSceneDesc::contactCorrelationDistance removed.</li>
+                <li>Indexing operators taking signed integers in PxVec3, PxVec4, PxMat33, PxMat44, PxStrideIterator have been removed.</li>
+                <li>PxHitFlag::ePOSITION, PxHitFlag::eDISTANCE and PxHitFlag::eNORMAL are now supported in PxMeshQuery::sweep function.</li>
+                <li>PxClothFlag::eGPU renamed to PxClothFlag::eCUDA.</li>
+                <li>PxActorTypeSelectionFlag/PxActorTypeSelectionFlags. Use PxActorTypeFlag/PxActorTypeFlags instead.</li>
+                <li>PxConstraintFlag::eDEPRECATED_32_COMPATIBILITY flag removed.</li>
+            </ul>
+        </ul>
+
+        <h3>PxShared</h3>
+        <ul>
+            APEX 1.4 can now be used independently of PhysX. In order to
+ achieve that a new shared code base was created called "PxShared". 
+PhysX functionality such as common types, PxFoundation, the task 
+infrastructure are now part of PxShared.
+        </ul>
+
+        <h3>Rigid Bodies</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>An alternative simulation API has been introduced. 
+This makes use of the following new functions: PsScene:collide(), 
+PxScene::fetchCollision() and PxScene::advance(). Expected usage of 
+these functions is illustrated in a new snippet SnippetSplitSim. This 
+feature is also described in the manual in Section 
+Simulation-&gt;SplitSim.</li>
+                <li>PxSceneFlag::eDEPRECATED_TRIGGER_TRIGGER_REPORTS has
+ been introduced to re-enable the legacy behavior of trigger shape pairs
+ sending reports. This flag and the corresponding legacy behavior will 
+be removed in version 4.</li>
+                <li>The active actors feature has been added. See PxSceneFlag::eENABLE_ACTIVE_ACTORS.</li>
+                <li>Functionality to compute and manipulate mass, 
+inertia tensor and center of mass of objects has been exposed in the new
+ class PxMassProperties.</li>
+                <li>The option to exclude kinematics from the active 
+actors/transforms list has been added. See 
+PxSceneFlag::eEXCLUDE_KINEMATICS_FROM_ACTIVE_ACTORS for details.</li>
+                <li>The integrated pose of dynamic rigid bodies can be 
+accessed earlier in the pipeline through a new callback (see the API 
+documentation for PxSimulationEventCallback::onAdvance() and 
+PxRigidBodyFlag::eENABLE_POSE_INTEGRATION_PREVIEW for details).</li>
+                <li>PxConvexMeshGeometryFlag::eTIGHT_BOUNDS has been added. See the user manual for details.</li>
+                <li>New split fetchResults methods introduced, see 
+PxScene::fetchResultsBegin(), PxScene::fetchResultsFinish() and 
+PxScene::processCallbacks(). This is intended to permit the application 
+to parallelize the event notification callbacks.</li>
+                <li>New flag introduced to suppress updating scene query
+ pruner trees inside fetchResults, see 
+PxSceneFlag::eSUPPRESS_EAGER_SCENE_QUERY_REFIT. Instead, pruners will be
+ updated during the next query.</li>
+                <li>Introduced GPU rigid body simulation support, see 
+PxSceneFlag::eENABLE_GPU_DYNAMICS. GPU rigid body support requires SM3.0
+ or later.</li>
+                <li>Introduced a new GPU-accelerated broad phase. See PxBroadPhaseType::eGPU. GPU broad phase support requires SM3.0 or later.</li>
+                <li>Introduced a new enhanced determinism mode. See 
+PxSceneFlag::eENABLE_ENHANCED_DETERMINISM. This provides additional 
+levels of rigid body simulation determinism at the cost of some 
+performance.</li>
+                <li>Introduced a new speculative contacts CCD approach. 
+See PxRigidBodyFlag::eENABLE_SPECULATIVE_CCD. This is a slightly 
+cheaper, less robust solution to PxRigidBodyFlag::eENABLE_CCD. There is 
+no need to turn CCD on the scene using PxSceneFlag::eENABLE_CCD or 
+enable PxPairFlag::eDETECT_CCD_CONTACT with this CCD mode as it 
+functions as an extension to the discrete time-stepping scheme. This 
+form of CCD can be enabled on kinematic actors. </li>
+                <li>New "immediate mode" API has been added. This 
+exposes access to the low-level contact generation and constraint 
+solver, which allows the application to use these PhysX low-level 
+components to perform its own simulations without needing to populate 
+and simulate a PxScene.</li>
+                <li>RigidDynamic lock flags added which permit the 
+application to disallow rotation/translation of PxRigidDynamics around 
+specific axes.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>PxRigidStatic objects can now have zero shapes while being part of a scene.</li>
+                <li>PxContactPairFlag::eINTERNAL_HAS_FACE_INDICES is obsolete and has been removed.</li>
+                <li>PxConstraintFlag::eDEPRECATED_32_COMPATIBILITY was 
+previously only implemented for spring constraints. It is now correctly 
+implemented for equality constraints.</li>
+                <li>PxSceneFlag::eENABLE_PCM is enabled by default. This means PhysX uses PCM distance-based collision detection by default. </li>
+                <li>Calls to PxRigidDynamic::setWakeCounter() following 
+PxScene::collide() do now explicitly get taken into account in the 
+subsequent call to PxScene::advance().</li>
+                <li>Calls to contact modification callbacks can be made 
+from multiple threads simultaneously. Therefore, modification callbacks 
+should must be thread-safe. </li>
+                <li>Unified heightfield contact generation is now the 
+default heightfield contact generation approach. This approach offers 
+similar performance and behavior to contact generation with triangle 
+meshes. Unified heightfields have no thickness because contact 
+generation operates on triangles so objects may tunnel if CCD is not 
+enabled.</li>
+                <li>When unified heightfield contact generation is in use, the bounds of heightfield shapes are no longer extruded by "thickness".</li>
+                <li>PxArticulationJoint::setTwistLimit and 
+PxArticulationJoint::getTwistLimit were incorrectly documented with 
+zLimit and yLimit in the wrong order.  The behavior of both functions 
+remains unchanged but now they are correctly documented with zLimit and 
+yLimit in the correct order. This is simply a clarification of the 
+existing function behavior.</li>
+            </ul>
+            <li>Removed:</li>
+            <ul>
+                <li>The deprecated class PxFindOverlapTriangleMeshUtil has been removed. Please use PxMeshOverlapUtil instead.</li>
+                <li>The deprecated flag PxConstraintFlag::eREPORTING has been removed. Force reports are now always generated.</li>
+                <li>The following deprecated simulation event flags have
+ been removed: PxContactPairHeaderFlag::eDELETED_ACTOR_0, 
+::eDELETED_ACTOR_1, PxContactPairFlag::eDELETED_SHAPE_0, 
+::eDELETED_SHAPE_1, PxTriggerPairFlag::eDELETED_SHAPE_TRIGGER, 
+::eDELETED_SHAPE_OTHER. Please use the following flags instead: 
+PxContactPairHeaderFlag::eREMOVED_ACTOR_0, ::eREMOVED_ACTOR_1, 
+PxContactPairFlag::eREMOVED_SHAPE_0, ::eREMOVED_SHAPE_1, 
+PxTriggerPairFlag::eREMOVED_SHAPE_TRIGGER, ::REMOVED_SHAPE_OTHER.</li>
+                <li>The deprecated method 
+PxPhysics::createHeightField(const PxHeightFieldDesc&amp;) has been 
+removed. Please use PxCooking::createHeightField(const 
+PxHeightFieldDesc&amp;, PxPhysicsInsertionCallback&amp;) instead. The 
+insertion callback can be obtained through 
+PxPhysics::getPhysicsInsertionCallback().</li>
+            </ul>
+            <li>Deprecated:</li>
+            <ul>
+                <li>PxRigidActor::createShape() has been deprecated in favor of PxRigidActorExt::createExclusiveShape()</li>
+                <li>Trigger notification events for trigger-trigger 
+pairs have been deprecated and will be omitted by default. See the 3.4 
+migration guide for more information.</li>
+                <li>The active transforms feature 
+(PxSceneFlag::eENABLE_ACTIVETRANSFORMS) has been deprecated. Please use 
+PxSceneFlag::eENABLE_ACTIVE_ACTORS instead. </li>
+                <li>PxRegisterHeightFields has been modified to register
+ unified heightfields, which are now the default implementation. 
+PxRegisterLegacyHeightFields() has been added to register the legacy 
+(deprecated) heightfield contact gen approach.</li>
+                <li>PxHeightFieldDesc::thickness has been deprecated, as
+ the new unified height field (see PxRegisterUnifiedHeightFields()) does
+ not support thickness any longer.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>The capsule-vs-heightfield contact generation had a 
+rare bug where a vertical capsule standing exactly on a shared edge 
+could fall through a mesh. This has been fixed.</li>
+                <li>The bounding box of a shape was not always properly updated when the contact offset changed.</li>
+                <li>Fixed a bug in the GJK sweep caused by lost precision in the math</li>
+                <li>Calls to PxScene::shiftOrigin() can crash when PxRigidDynamic actors with PxActorFlag::eDISABLE_SIMULATION are present.</li>
+                <li>Fixed a bug when PxShape::setMaterials was called with less materials than shape had before.</li>
+                <li>Fixed a bug in CCD that could lead to a hang in the simulation.</li>
+                <li>Fixed a bug in PCM mesh edge-edge check for the parallel case. </li>
+                <li>Fixed a bug in CCD where contact modify callbacks could be called when the CCD did not detect a contact.</li>
+                <li>Fixed a bug with applying external force/torque to a body in buffered insertion stage.</li>
+                <li>A rare capsule-vs-mesh contact generation bug has been fixed.</li>
+                <li>A rare crash due to an invalid assert in the MBP 
+broad-phase has been fixed. This error only affected debug &amp; checked
+ builds; release &amp; profile builds were unaffected.</li>
+            </ul>
+        </ul>
+
+        <h3>Particles</h3>
+        <ul>
+            <li>Gpu: Maxwell Optimizations</li>
+            <li>The PhysX particle feature has been deprecated.</li>
+            <li>Fixed particle collision issue with 
+PxParticleBaseFlag::ePER_PARTICLE_COLLISION_CACHE_HINT (on by default). 
+When particles collided against very dense triangle mesh areas an assert
+ would be triggered or particles would leak through the triangle mesh. A
+ workaround was to disable 
+PxParticleBaseFlag::ePER_PARTICLE_COLLISION_CACHE_HINT.</li>
+        </ul>
+
+        <h3>Cloth</h3>
+        <ul>
+            <li>Continuous collision (PxClothFlag::eSWEPT_CONTACT) behavior has been optimized to reduce cloth sticking to collision shape.</li>
+            <li>Added air resistance feature (see 
+PxCloth::setWindVelocity(PxVec3), PxCloth::setWindDrag(PxReal), 
+PxCloth::setWindLift(PxReal), PxClothFabricDesc::nbTriangles, 
+PxClothFabricDesc::triangles.</li>
+        </ul>
+
+        <h3>Serialization</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxTriangleMesh instances with adjacency information 
+were not correctly initialized when created with 
+cooking.createTriangleMesh. This caused a crash when converting the 
+binary serialized triangle mesh data. </li>
+            </ul>
+        </ul>
+
+        <h3>Character controller</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>Profile zones have been added for the character controller.</li>
+                <li>Added PxControllerDesc::registerDeletionListener boolean defining if deletion listener for CCT should be registered.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Character controllers cannot stand on dynamic triggers anymore.</li>
+                <li>Fixed: the capsule-vs-sphere sweep now returns a normal in the correct direction.</li>
+                <li>Fixed a bug where CCT shapes initially overlapping 
+static geometry would be moved down by an incorrect amount (the length 
+of the step offset).</li>
+                <li>The overlap recovery module now works against kinematic objects.</li>
+            </ul>
+        </ul>
+
+        <h3>Vehicles</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>
+                    Anti-roll suspension has been added.    The class 
+PxVehicleAntiRollBar and the functions 
+PxVehicleWheelsSimData::setAntiRollBar,
+                    PxVehicleWheelsSimData::getAntiRollBar, 
+PxVehicleWheelsSimData::getNbAntiRollBars allow anti-roll bars to be 
+configured and queried.
+                </li>
+                <li>
+                    A new function PxVehicleSuspensionSweeps has been 
+introduced.  This sweeps the PxShape that represents the wheel along the
+ suspension direction. The hit planes resulting
+                    from the sweep are used as driving surfaces similar 
+to those found by PxVehicleSuspensionRaycasts.
+                </li>
+                <li>
+                    A new snippet SnippetVehicleContactMod has been 
+added.  This snippet demonstrates how to use sweeps and contact 
+modification to allow the wheel's volume to fully interact
+                    with the environment.
+                </li>
+                <li>A new function PxVehicleModifyWheelContacts has been
+ introduced.  This function analyses contact in the contact modification
+ callback and rejects contact points that represent drivable surfaces.</li>
+                <li>A new function PxVehicleSetMaxHitActorAcceleration 
+has been introduced.  This function sets the maximum acceleration 
+experienced by a PxRigidDynamic that finds itself under the wheel of a 
+vehicle.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>
+                    In checked build the functions 
+PxVehicleDrive4W::allocate, PxVehicleDriveNW::allocate, 
+PxVehicleDriveTank::allocate, PxVehicleNoDrive::allocate all return NULL
+ and issue a warning if called before
+                    PxInitVehicleSDK.
+                </li>
+                <li>Tire width is no longer accounted for when computing
+ the suspension compression from raycasts (PxVehicleSuspensionRaycasts).
+  Instead, tire width is incorporated into the suspension compression 
+arising from swept wheels (PxVehicleSuspensionSweeps).  It is 
+recommended to use PxVehicleSuspensionSweeps if there is a strict 
+requirement that the inside and outside of the wheel don't visibly 
+penetrate geometry.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Suspension force calculation now applies an extra 
+force perpendicular to the spring travel direction. This force is 
+calculated to satisfy the constraint that the sprung mass only has 
+motion along the spring travel direction.  This change mostly affects 
+vehicles with suspension travel directions that are not vertical.</li>
+                <li>PxVehicleWheelsSimData::mThresholdLongitudinalSpeed 
+and PxVehicleWheelsSimData::mMinLongSlipDenominator are now given 
+default values that reflect the length scale set in PxTolerancesScale.</li>
+                <li>Unphysically large constraint forces were generated 
+to resolve the suspension compression beyond its limit when the 
+suspension direction and the hit normal under the wheel approach 
+perpendicularity.  This has been fixed so that the constraint force 
+approaches zero as the angle between the hit normal and suspension 
+direction approaches a right angle.</li>
+            </ul>
+        </ul>
+
+        <h3>Scene queries</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>PxPruningStructure was introduced as an optimization
+ structure to accelerate scene queries against large sets of newly added
+ actors.</li>
+                <li>PxScene::addActors(PxPruningStructure&amp; ) has been added.</li>
+                <li>PxMeshQuery::sweep now supports PxHitFlag::eMESH_ANY.</li>
+                <li>PxHitFlag::eFACE_INDEX was introduced to reduce the 
+perf cost for convex hull face index computation. In order to receive 
+face index for sweeps against a convex hull, the flag 
+PxHitFlag::eFACE_INDEX has to be set. Note that the face index can also 
+be computed externally using the newly introduced method PxFindFaceIndex
+ from the extensions library.</li>
+                <li>PxGeometryQuery::isValid was added to check provided geometry validity.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>Raycasts against triangle meshes with 
+PxHitFlag::eMESH_MULTIPLE flag now return all hits, code for discarding 
+hits close to each other has been removed.</li>
+                <li>PxPruningStructure enum has been renamed to PxPruningStructureType</li>
+            </ul>
+            <li>Deprecated:</li>
+            <ul>
+                <li>PxHitFlag::eDISTANCE has been deprecated.</li>
+                <li>The batched query feature has been deprecated.</li>
+                <li>Volume cache feature has been deprecated.</li>
+                <li>Spatial index feature has been deprecated.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxScene::sweep now properly implements 
+PxHitFlag::eMESH_BOTH_SIDES (returned normal follows the same convention
+ as for raycasts).</li>
+                <li>Raycasts against heightfields now correctly return multiple hits when PxHitFlag::eMESH_MULTIPLE flag is used.</li>
+                <li>PxSweepHit.faceIndex was computed incorrectly for 
+sweep tests initially overlapping convex objects. The face index is now 
+set to 0xffffffff in these cases.</li>
+                <li>Convex vs convex sweeps in PxGeometryQuery::sweep() 
+do now correctly return the face index of the convex mesh that gets 
+passed in as parameter geom1 (and not the one from geom0).</li>
+                <li>PxMeshQuery::sweep now supports PxHitFlag::eMESH_ANY.</li>
+                <li>Deprecated definition PxSceneQueryHit has been removed. Please use PxQueryHit instead.</li>
+                <li>PxGeometryQuery::computePenetration with convex geometries.</li>
+                <li>On Android platforms, the eDYNAMIC_AABB_TREE pruning
+ structure could pass already released objects into the scene query 
+filter callback.</li>
+            </ul>
+        </ul>
+
+
+        <h3>Cooking</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>PxTriangleMeshCookingResult added, cookTriangleMesh 
+now does return additional PxTriangleMeshCookingResult. Please see the 
+manual for more information.</li>
+                <li>New convex hull generator added. It is now possible 
+to switch between a new quickhull implementation and the legacy 
+inflation based hull. Quickhull is the default algorithm.</li>
+                <li>Convex hulls can now be directly inserted in PxPhysics as triangle meshes and height fields.</li>
+                <li>A separate convex hull validation function has been added, it is now possible to create hulls without validation.</li>
+                <li>Convex hull generator vertex limit has two different algorithms - plane shifting and OBB slicing.</li>
+                <li>PxConvexFlag::eFAST_INERTIA_COMPUTATION added. When enabled, the inertia tensor is computed faster but with less precision.</li>
+                <li>PxConvexFlag::eGPU_COMPATIBLE added. When enabled 
+convex hulls are created with vertex limit set to 64 and vertex limit 
+per face is 32.</li>
+                <li>PxConvexFlag::eSHIFT_VERTICES added. When enabled input points are shifted to be around origin to improve computation stability.</li>
+                <li>PxCookingParams::gaussMapLimit has been added. The 
+limit can now be fully user-defined. Please refer to the migration guide
+ and best practices sections of the manual.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>The performance of convex creation from polygons has been improved.</li>
+            </ul>
+            <li>Deprecated:</li>
+            <ul>
+                <li>The PxPlatform enum and the PxGetGaussMapVertexLimitForPlatform function have been deprecated.</li>
+            </ul>
+            <li>Removed:</li>
+            <ul>
+                <li>The deprecated flags 
+PxMeshPreprocessingFlag::eREMOVE_UNREFERENCED_VERTICES and 
+::eREMOVE_DUPLICATED_TRIANGLES have been removed. Meshes get cleaned up 
+by default unless PxMeshPreprocessingFlag::eDISABLE_CLEAN_MESH is set.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Mesh cooking was sometimes crashing for meshes with less than 4 triangles. This has been fixed.</li>
+                <li>Cooking convex mesh from a flat input mesh produced incorrect large mesh.</li>
+            </ul>
+        </ul>
+
+        <h3>Extensions</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>PxRaycastCCD has been added, to improve the 
+visibility of the raycast-based CCD solution, which was previously only 
+available in the Sample framework. This is a simpler and potentially 
+cheaper alternative to the SDK's built-in continuous collision detection
+ algorithm.</li>
+                <li>PxFindFaceIndex has been added. The function computes the closest polygon on a convex mesh from a given hit point and direction.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>Memory churn of PxDefaultMemoryOutputStream has been reduced.</li>
+                <li>The signatures for the PxComputeMeshPenetration and PxComputeHeightFieldPenetration functions have changed.</li>
+            </ul>
+        </ul>
+
+        <h3>Profiling</h3>
+        <ul>
+            <li>Changed:</li>
+            <ul>
+                <li>Profiling information is now available only in debug, checked and profile configuration.</li>
+                <li>PxProfileZoneManager::createProfileZoneManager now takes PxAllocatorCallback as input parameter instead of PxFoundation.</li>
+            </ul>
+        </ul>
+
+        <h3>Physx Visual Debugger</h3>
+        <ul>
+            <li>PhysXVisualDebuggerSDK, PvdRuntime projects replaced with PxPvdSDK.</li>
+            <li>PxPvdSceneClient::drawPoints now takes 
+physx::pvdsdk::PvdDebugPoint as input parameter instead of PxDebugPoint.
+ drawLines, drawTriangles, drawText and so on.</li>
+            <li>The SDK's Debug visualization data is not sent to PVD anymore in ePROFILE mode.</li>
+            <li>PxPvdSceneFlag::eTRANSMIT_CONTACTS (instead of 
+PxPvdSceneFlag::eTRANSMIT_CONSTRAINTS) was sometimes incorrectly used to
+ control the transmission of constraint-related data. This has been 
+fixed. In addition, the PxPvdSceneFlag flags are now consistently 
+ignored when PxPvdInstrumentationFlag::eDEBUG is not set.</li>
+        </ul>
+
+        <h3>Aggregates</h3>
+        <ul></ul>
+
+        <h3>Snippets</h3>
+        <ul>
+            <li>Snippet profile zone has been removed.</li>
+        </ul>
+    </blockquote>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.3.4</h1>
+    <h2 style="TEXT-ALIGN: center">October 2015</h2>
+
+    <h2>Supported Platforms</h2>
+    <blockquote>
+        <h3>Runtime</h3>
+        <ul>
+            <li>Apple iOS</li>
+            <li>Apple Mac OS X</li>
+            <li>Google Android ARM &amp; x86 (version 2.2 or later required for SDK, 2.3 or later required for samples)</li>
+            <li>Linux (tested on Ubuntu)</li>
+            <li>Microsoft Windows XP or later (NVIDIA Driver version R304 or later is required for GPU acceleration)</li>
+            <li>Microsoft Windows RT (formerly known as Windows on ARM) (SDK only, no samples yet)</li>
+            <li>Microsoft XBox One (SDK only, no samples)</li>
+            <li>Microsoft XBox 360</li>
+            <li>Nintendo Wii U</li>
+            <li>Sony Playstation 3</li>
+            <li>Sony Playstation 4 (SDK only, no samples)</li>
+            <li>Sony Playstation Vita</li>
+        </ul>
+        <h3>Development</h3>
+        <ul>
+            <li>Microsoft Windows XP or later</li>
+            <li>Microsoft Visual Studio 2012, 2013 and 2015</li>
+            <li>Xcode 6.3</li>
+        </ul>
+    </blockquote>
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+        <h3>General</h3>
+        <ul>
+            <li>Added support for Microsoft Visual Studio 2015 for 
+Windows builds. Note that the GPU features are not currently supported 
+with Visual Studio 2015.</li>
+            <li>Removed support for Microsoft Visual Studio 2010</li>
+            <li>Added support for Android platform API Level 16 and removed support for platform API Level 8 and 9.</li>
+            <li>Fixed:</li>
+            <ul>
+                <li>Fixed a bug in aggregates that led to a crash when 
+rigid bodies are added to an aggregate after removing all rigid bodies 
+from an aggregate.   This only occurred with aggregates that were added 
+to the scene and with rigid bodies that had shapes attached.</li>
+            </ul>
+        </ul>
+
+        <h3>Rigid Bodies</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Creating a PxConstraint or using 
+PxConstraint::setActors() could cause a crash in situations where one of
+ the two newly connected actors was part of a previously simulated graph
+ of connected constraints (with some of them having projection enabled, 
+i.e., PxConstraintFlag::ePROJECT_TO_ACTOR0 or ::ePROJECT_TO_ACTOR1 set).</li>
+                <li>PxD6Joint::getTwist(), getSwingY(), getSwingZ() 
+returned incorrect angle values when the corresponding components of the
+ quaternion were negative</li>
+                <li>The thickness of a heightfield was incorrectly applied when the heightfield transform had a non-identity quaternion. </li>
+                <li>PxD6Joint angular projection now functions correctly when there is one free axis and it is not the twist axis.</li>
+                <li>The bounding box of a shape was not always properly updated when the contact offset changed.</li>
+                <li>Fixed an edge case bug in PCM contact gen that could result in a QNAN reported as the contact point.</li>
+                <li>Fixed an uninitialized variable bug in the GJK algorithm resulting in unintialized closest points reported.</li>
+                <li>Fixed an edge case in which the constraint solver could access invalid memory in constraint partitioning.</li>
+                <li>Fixed a bug in capsule vs heightfield contact generation that could produce incorrect penetration depths.</li>
+                <li>Fixed a bug in Unified MTD code path which transformed the normal twice for the polygon index calculation. </li>
+                <li>Fixed a crash in height fields when a capsule collided with an edge whose shared triangles had a hole material.</li>
+            </ul>
+        </ul>
+
+        <h3>Serialization</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxTriangleMesh instances with adjacency information 
+were not correctly initialized when created with 
+cooking.createTriangleMesh. This caused a crash when converting the 
+binary serialized triangle mesh data.</li>
+            </ul>
+        </ul>
+
+        <h3>Scene Queries</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Sweeps against scaled meshes.</li>
+            </ul>
+        </ul>
+
+        <h3>Cooking</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Mesh cooking was sometimes crashing for meshes with less than 4 triangles. This has been fixed.</li>
+            </ul>
+        </ul>
+
+    </blockquote>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.3.3</h1>
+    <h2 style="TEXT-ALIGN: center">January 2015</h2>
+
+    <h2>Supported Platforms</h2>
+    <blockquote>
+        <h3>Runtime</h3>
+        <ul>
+            <li>Apple iOS</li>
+            <li>Apple Mac OS X</li>
+            <li>Google Android ARM &amp; x86 (version 2.2 or later required for SDK, 2.3 or later required for samples)</li>
+            <li>Linux (tested on Ubuntu)</li>
+            <li>Microsoft Windows XP or later (NVIDIA Driver version R304 or later is required for GPU acceleration)</li>
+            <li>Microsoft Windows RT (formerly known as Windows on ARM) (SDK only, no samples yet)</li>
+            <li>Microsoft XBox One (SDK only, no samples)</li>
+            <li>Microsoft XBox 360</li>
+            <li>Nintendo Wii U</li>
+            <li>Sony Playstation 3</li>
+            <li>Sony Playstation 4 (SDK only, no samples)</li>
+            <li>Sony Playstation Vita</li>
+        </ul>
+        <h3>Development</h3>
+        <ul>
+            <li>Microsoft Windows XP or later</li>
+            <li>Microsoft Visual Studio 2010, 2012 and 2013</li>
+            <li>Xcode 6.2</li>
+        </ul>
+    </blockquote>
+    <h2>Known Issues</h2>
+    <blockquote>
+        <ul>
+            <li>The combination of releasing an actor and reassigning 
+the actors of any affected joint so that the joint no longer references 
+the released actor will lead to a crash if these operations are 
+performed as buffered calls ie after simulate but before fetchResults.</li>
+        </ul>
+    </blockquote>
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+        <h3>General</h3>
+        <ul>
+            <li>Added support for Microsoft Visual Studio 2013 and removed support for Microsoft Visual Studio 2008.</li>
+            <li>Where applicable, mutexes on Unix flavored platforms now
+ inherit priority to avoid priority inversion. This is a default 
+behavior of Windows mutexes.</li>
+            <li>Added arm64 support for the iOS version of the PhysX SDK.</li>
+            <li>Removed samples from the iOS version of the PhysX SDK.</li>
+            <li>Fixed:</li>
+            <ul>
+                <li>x64 samples running on Windows 8.</li>
+                <li>Concurrent calls to 
+PxPhysics::(un)registerDeletionListener() and 
+PxPhysics::(un)registerDeletionListenerObjects() were not safe.</li>
+                <li>PxGeometryQuery::pointDistance() could sometimes read uninitialized memory. This has been fixed.</li>
+                <li>The SDK will not crash anymore if an object is 
+involved in more than 65535 interactions. Instead, it will emit an error
+ message and the additional interactions will be ignored.</li>
+                <li>The PxPhysics::getMaterials() function did not work with a non-zero 'startIndex' parameter. This has been fixed.</li>
+                <li>The following static Android libs are now packed 
+into a single library called PhysX3: LowLevel, LowLevelCloth, PhysX3, 
+PhysXProfileSDK, PhysXVisualDebuggerSDK, PvdRuntime, PxTask, SceneQuery 
+and SimulationController. This fixes cyclic dependencies between these 
+libraries.</li>
+                <li>FSqrt(0), V4Sqrt(0), V4Length(0) and V3Length(0) will return 0 instead of QNan in Android and iOS.</li>
+            </ul>
+        </ul>
+
+        <h3>Rigid Bodies</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>The Prismatic joint limit now acts correctly when its frame is not the identity.</li>
+                <li>Calling PxRigidDynamic::setGlobalPose() with the 
+autowake parameter set to true could result in an assert when the rigid 
+body got released and had the PxActorFlag::eDISABLE_SIMULATION flag set.</li>
+                <li>Added errors on misuse of PxRegister[Unified]Heightfields() function, and documented it.</li>
+                <li>PxConstraint has a eDISABLE_PREPROCESSING flag and 
+minResponseThreshold attribute to assist in stabilizing stiffness caused
+ by infinite inertias or mass modification.</li>
+                <li>Island manager performance in the presence of large numbers of kinematic actors has been improved.</li>
+                <li>Using PxConstraint::setActors() or 
+PxJoint::setActors() could cause a crash if the new actors resulted in 
+the constraint/joint being removed from the scene.</li>
+                <li>The functions PxRigidActor::setGlobalPose and 
+PxShape::setLocalPose failed to update cached contact data internal to 
+PhysX.  This led to contacts being generated with transforms that were 
+no longer valid.  Similarly, contacts could be missed due to transforms 
+being invalid.  This defect affected the classes PxRigidStatic and 
+PxRigidDynamic, though it was more immediately noticeable with the 
+PxRigidStatic class.</li>
+                <li>The sphere-vs-mesh contact generation code has been improved. It could previously generate wrong contacts. This has been fixed.</li>
+                <li>The capsule-vs-convex contact generation had a bug that could lead to rare invalid contacts. This has been fixed.</li>
+                <li>The mesh contact generation had a bug on PS3 that could lead to invalid contacts. This has been fixed.</li>
+                <li>The PxRigidBody::clearForce() and 
+PxRigidBody::clearTorque() were not properly decoupled - they both 
+cleared the force and the torque. This has been fixed.</li>
+                <li>Repeatedly calling PxRigidActor::attachShape and 
+PxRigidActor::detachShape in between calls to simulate resulted in a 
+memory leak.  This has been fixed.</li>
+            </ul>
+            <li>Added:</li>
+            <ul>
+                <li>Enabling CCD on kinematic actors is now disallowed. 
+When the kinematic flags are raised on a CCD-enabled actor, CCD is 
+automatically disabled. </li>
+            </ul>
+        </ul>
+
+        <h3>Particles</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>
+                    Consistency between GPU and CPU particles has been 
+improved in the case of a spatial date structure overflow. The positions
+ and velocities of particles that have the 
+PxParticleFlag::eSPATIAL_DATA_STRUCTURE_OVERFLOW set
+                    are now updated also for CPU particles.
+                </li>
+                <li>Fixed potential deadlocks from occurring in the GPU particle kernels running on GM204 and above GPUs.</li>
+                <li>Fixed fluid simulation crash on Titan X.</li>
+            </ul>
+        </ul>
+
+        <h3>Cloth</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>A bug related to hitting the sphere or plane limit while world collision is enabled has been fixed.</li>
+                <li>PxCloth::getParticleAccelerations() implementation was fixed for GPU cloth.</li>
+            </ul>
+        </ul>
+
+        <h3>Character controller</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Character controllers cannot stand on dynamic triggers anymore.</li>
+            </ul>
+            <li>Added:</li>
+            <ul>
+                <li>added lockingEnabled parameter to 
+PxCreateControllerManager(), to support thread-safe release of objects 
+while the character controller's move() routine is executing.</li>
+            </ul>
+        </ul>
+
+        <h3>Scene Queries</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Raycasts against triangle meshes with large scales potentionaly failed to register a hit.</li>
+                <li>Overlaps against height field meshes with the flag eNO_BOUNDARY_EDGES potentionaly failed to register a hit.</li>
+                <li>Sweeps using shapes modelled around a space significantly offset from their geometric center could fail to register a hit. </li>
+            </ul>
+        </ul>
+
+        <h3>Vehicles</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Sticky tire friction was unreliable with more than 
+one substep but is now fixed.  This defect led to vehicles sliding down 
+slopes where the sticky friction should have held firm.</li>
+                <li>An error in the jounce speed calculation that led to
+ lift force at high forward speeds has been fixed.  This defect led to 
+instabilities at high speed.</li>
+                <li>Improved documentation for PxVehicleSuspsensionData::mSprungMass.</li>
+            </ul>
+        </ul>
+
+        <h3>Cooking</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Convex meshes generated from PhysX 3.2 were not able to load inside PhysX 3.3.</li>
+            </ul>
+        </ul>
+
+    </blockquote>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.3.2</h1>
+    <h2 style="TEXT-ALIGN: center">September 2014</h2>
+
+    <h2>Supported Platforms</h2>
+    <blockquote>
+        <h3>Runtime</h3>
+        <ul>
+            <li>Apple iOS</li>
+            <li>Apple Mac OS X</li>
+            <li>Google Android ARM &amp; x86 (version 2.2 or later required for SDK, 2.3 or later required for samples)</li>
+            <li>Linux (tested on Ubuntu)</li>
+            <li>Microsoft Windows XP or later (NVIDIA Driver version R304 or later is required for GPU acceleration)</li>
+            <li>Microsoft Windows RT (formerly known as Windows on ARM) (SDK only, no samples yet)</li>
+            <li>Microsoft XBox One (SDK only, no samples)</li>
+            <li>Microsoft XBox 360</li>
+            <li>Nintendo Wii U</li>
+            <li>Sony Playstation 3</li>
+            <li>Sony Playstation 4 (SDK only, no samples)</li>
+            <li>Sony Playstation Vita</li>
+        </ul>
+        <h3>Development</h3>
+        <ul>
+            <li>Microsoft Windows XP or later</li>
+            <li>Microsoft Visual Studio 2008, 2010, 2012 (Windows RT only)</li>
+            <li>Xcode 4.6|5.0|5.0.1</li>
+        </ul>
+    </blockquote>
+    <h2>Known Issues</h2>
+    <blockquote>
+        <ul>
+            <li>The combination of releasing an actor and reassigning 
+the actors of any affected joint so that the joint no longer references 
+the released actor will lead to a crash if these operations are 
+performed as buffered calls ie after simulate but before fetchResults.</li>
+        </ul>
+    </blockquote>
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+        <h3>General</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>The PhysXCommon/64.dll, nvcuda.dll and 
+PhysXUpdateLoader/64.dll are loaded and checked for the NVIDIA 
+Corporation digital signature. The signature is expected on all NVIDIA 
+Corporation provided dlls. The application will exit if the signature 
+check fails.</li>
+                <li>Added the PxDefaultBufferedProfiler extension for simplified SDK profile events extraction.</li>
+                <li>PxSceneDesc::sanityBounds allows a bounding box to 
+be set for validating the position coordinates of inserted or updated 
+rigid actors and articulations.</li>
+                <li>Linux: Now supports GPU PhysX.</li>
+                <li>Added set/getRunProfiled() for PxDefaultCpuDispatcher to control profiling at task level.</li>
+                <li>Android: Support for x86 based devices was added.</li>
+                <li>PxProfileEventHandler::durationToNanoseconds() added. Translates event duration in timestamp (cycles) into nanoseconds.</li>
+                <li>Added SnippetProfileZone to show how to retrieve profiling information.</li>
+                <li>Added SnippetCustomJoint to better illustrate custom joint implementation, and removed SnippetExtension.</li>
+                <li>Added SnippetStepper to demonstrate kinematic updates while substepping with tasks.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxTask::runProfiled() now takes threadId as a parameter.</li>
+                <li>The static pruner now issues a performance warning 
+in debug and checked configurations when a tree rebuild occurs and the 
+tree is not empty.</li>
+                <li>PxSceneDesc::staticStructure now defaults to PxPruningStructure::eDYNAMIC_AABB_TREE.</li>
+                <li>Linux: Switched to shared libraries.</li>
+                <li>Profile zone event names changed to match function calls.</li>
+                <li>Overlapping read/write errors will now issue a PxErrorCode::eINVALID_OPERATION rather than PxErrorCode::eDEBUG_INFO.</li>
+                <li>Improved SnippetToleranceScale to better demonstrate the intended use case.</li>
+                <li>Increased 126 characters limit for warnings on unix platforms, 1k limit on all platforms.</li>
+                <li>PhysXCommon dll load within PhysX dll now respects dll name. Please see the manual's PhysXCommon DLL load section.</li>
+                <li>Significant revision of the user's guide.  Both structure and most content have been modified.</li>
+                <li>Fixed search function of user's guide.</li>
+                <li>Foundation math classes now have in-place arithmetic operators (+= etc).</li>
+                <li>PxScene::checkResults() no longer counts as a read 
+API method. Hence it is now possible to call this method in blocking 
+mode without causing all writes to block until it returns.</li>
+            </ul>
+            <li>Deprecated:</li>
+            <ul>
+                <li>Indexing operators taking signed integers in PxVec3, PxVec4, PxMat33, PxMat44, PxStrideIterator have been deprecated.</li>
+            </ul>
+        </ul>
+
+        <h3>Rigid Bodies</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>A minor bug in contact generation between capsules 
+and triangle meshes has been fixed, reducing the amount of tunneling 
+cases when CCD is not used.</li>
+                <li>Discrete contact reports are no longer produced for 
+pairs without PxPairFlag::eDETECT_DISCRETE_CONTACT raised in the filter 
+shader. Previously, discrete contact generation would always have been 
+performed regardless of the presence of the 
+PxPairFlag::eDETECT_DISCRETE_CONTACT flag. This change potentially 
+improves performance when using  specific shapes for CCD-only collision,
+ which would have previously generated discrtete contacts and then 
+ignored them in the solver. </li>
+                <li>Trigger reports are no longer produced for pairs 
+without PxPairFlag::eDETECT_DISCRETE_CONTACT raised in the filter 
+shader. PxPairFlag::eTRIGGER_DEFAULT has been modified to include the 
+PxPairFlag::eDETECT_DISCRETE_CONTACT flag.</li>
+                <li>An incorrect PX_DEPRECATED annotation on the default constructor for PxD6JointDrive has been removed.</li>
+                <li>PxRigidDynamic::getKinematicTarget() returned a 
+wrong transform if the actor center of mass pose was different from the 
+actor global pose.</li>
+                <li>Switching a PxRigidDynamic from dynamic to kinematic
+ did not properly suppress existing pairs which turned into 
+kinematic-kinematic or kinematic-static pairs.</li>
+                <li>PxRigidDynamic::isSleeping() did not return the 
+correct value on the frame the object got inserted if 
+PxScene::addActors() was used and if the object was awake.</li>
+                <li>PxSceneFlag::eDISABLE_CONTACT_CACHE now correctly works on PS3/SPU.</li>
+                <li>If an object was added to the scene, put asleep and 
+had overlap with another sleeping object then contact points for that 
+pair might not have been reported once the object woke up.</li>
+                <li>Potential crash when calling 
+PxScene::resetFiltering() mulitple times for the same actor while the 
+simulation was running has been fixed.</li>
+                <li>Potential crash when using PxScene::resetFiltering()
+ with shapes that were just added while the simulation was running has 
+been fixed.</li>
+                <li>A crash in MBP when deleting an object that just went out of broad-phase bounds has been fixed.</li>
+                <li>A new drive mode has been added to drive articulation joints using rotation vectors.</li>
+                <li>In contact and trigger reports, the shape references
+ in PxTriggerPair and PxContactPair might not have been properly marked 
+as removed shapes if the removal took place while the simulation was 
+running.</li>
+                <li>PxPairFlag::eSOLVE_CONTACT is now properly observed 
+if the flag is not set on a contacting pair. A consequence of this fix 
+is that sleeping actors will no longer be woken up due to contact or 
+lost contact with awake actors if PxPairFlag::eSOLVE_CONTACT is not set 
+for the pair.  This also affects kinematic-kinematic pairs if one 
+kinematic of the pair moves out of contact with the other.  Behaviour is
+ unaffected for any pair that has PxPairFlag::eSOLVE_CONTACT set.</li>
+                <li>A memory leak with buffered shape and actor removal 
+has been fixed.  The memory leak occurred when the release of an actor's
+ shapes was followed by the release of the actor, all in-between 
+simulate() and fetchResults().</li>
+                <li>A bug was fixed which caused incorrect force reports to sometimes be reported.</li>
+                <li>Fixed a bug where incorrect normals were reported when using PCM contact gen.</li>
+                <li>Fixed some issues with scaled convex hulls in the PCM contact gen code path.</li>
+                <li>The accuracy of capsule collision code has been improved.</li>
+                <li>An isValid() method has been added to constraints, 
+that is satisfied if and only if at least one actor is a dynamic body or
+ articulation link</li>
+                <li>A check has been added to prevent constraint construction or modification that would leave the constraint invalid.</li>
+                <li>In checked builds the PxScene methods addActor(), 
+addActors(), addAggregate() and addCollection() will warn and return if 
+an invalid constraint would be added to the scene</li>
+            </ul>
+            <li>Deprecated:</li>
+            <ul>
+                <li>The following flags have been renamed and deprecated because the name did not properly reflect the root cause.</li>
+                <ul>
+                    <li>PxContactPairHeaderFlag</li>
+                    <ul>
+                        <li>eDELETED_ACTOR_0 (use eREMOVED_ACTOR_0 instead)</li>
+                        <li>eDELETED_ACTOR_1 (use eREMOVED_ACTOR_1 instead)</li>
+                    </ul>
+                    <li>PxContactPairFlag</li>
+                    <ul>
+                        <li>eDELETED_SHAPE_0 (use eREMOVED_SHAPE_0 instead)</li>
+                        <li>eDELETED_SHAPE_1 (use eREMOVED_SHAPE_1 instead)</li>
+                    </ul>
+                    <li>PxTriggerPairFlag</li>
+                    <ul>
+                        <li>eDELETED_SHAPE_TRIGGER (use eREMOVED_SHAPE_TRIGGER instead)</li>
+                        <li>eDELETED_SHAPE_OTHER (use eREMOVED_SHAPE_OTHER instead)</li>
+                    </ul>
+                </ul>
+            </ul>
+        </ul>
+
+        <h3>Vehicles</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>In profile config the functions PxVehicleUpdates, 
+PxVehiclePostUpdates and PxVehicleSuspensionRaycasts are now tracked 
+with profile events (provided that a PxProfileZoneManager instance was 
+passed to PxCreatePhysics).  These profile events can be viewed in 
+profile view in pvd, where the names of the profile events match the 
+names of the tracked vehicle functions.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>In checked config PxVehicleDriveTank::allocate 
+enforces the rule that only tanks with even numbers of wheels are legal 
+and warns when this rule is broken.</li>
+                <li> In checked config PxVehicleDrive4W::allocate 
+enforces the rule that only vehicles with 4 wheels or more are legal and
+ warns when this rule is broken.</li>
+                <li>PxWheelQueryResult::localPose was incorrectly only 
+set when the vehicle had a corresponding PxShape, as described by 
+PxVehicleWheelsSimData::setWheelShapeMapping.  The localPose is now 
+properly set independent of the mapping between wheel and shape.</li>
+                <li>Wheels resting on moving actors now properly observe
+ the relative speed of the two actors when their relative speed is 
+small.  This fixes a bug where at small relative speeds the velocity of 
+the other actor was assumed to be zero.</li>
+                <li>Repx serialization failed to serialize 
+PxVehicleWheelsSimData::setMinLongSlipDenominator, 
+PxVehicleWheelsSimData::setSubStepCount, 
+PxVehicleWheelsSimData::disableWheel, 
+PxVehicleWheelsSimData::enableWheel and the number of entries in the 
+engine torque curve.  These have now been fixed.</li>
+                <li>PxVehicleConcreteType used for vehicle serialization is now in the public API and has been moved to PxVehicleSDK.h.</li>
+                <li>Very small longitudinal and lateral slip angles 
+could lead to numerical instabilities in some circumstances.  A 
+threshold has been introduced to reject very small slip angles by 
+setting them to zero when they are below the threshold.</li>
+                <li>Vehicles now account for rigid bodies that have been
+ given a zero inertia component in order to lock rotation around the 
+corresponding axis.</li>
+                <li>Fixed a bug where the sticky wheel constraints sometimes didn't function correctly.</li>
+            </ul>
+        </ul>
+
+        <h3>Cloth</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>The version number written to the fabric stream 
+changed from PX_PHYSICS_VERSION to 1. A fabric can be created from 
+streams written with version 3.3.0 and later until the stream format 
+changes. Previously, the version of the producer and the consumer of the
+ stream needed to match.</li>
+                <li>GPU cloth friction against convexes has been fixed.</li>
+                <li>A crash resulting from deleting a shape in proximity of a cloth with scene collision enabled has been fixed.</li>
+            </ul>
+        </ul>
+
+        <h3>Scene Queries</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxMeshQuery::sweep now respects PxHitFlag::eMESH_BOTH_SIDES, and supports double-sided input triangles.</li>
+                <li>PxRigidBodyExt::linearSweepSingle and 
+PxRigidBodyExt::linearSweepMultiple now correctly use query filter data 
+instead of simulation filter data if filter data is not provided.</li>
+                <li>The spec for raycasts whose origin is located inside
+ a solid object (sphere, box, capsule, convex) has changed back to what 
+it was in 3.3.0. It was accidentally changed in 3.3.1. See the manual 
+for details.</li>
+                <li>Convex sweeps against heightfields worked only when 
+the heightfield had the identity transform.  This has now been fixed to 
+support arbitrary transforms again.</li>
+            </ul>
+        </ul>
+
+        <h3>Cooking</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>Using PxMeshPreprocessingFlag::eFORCE_32BIT_INDICES will always cook meshes with 32-bit triangle indices.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Convex hull cooking fix. Some input points could be ignored during cooking, fixed.</li>
+                <li>Inserted triangle meshes now respect 16 bit indices flag.</li>
+
+
+            </ul>
+        </ul>
+
+        <h3>Geometry</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxHeightFieldDesc::thickness is now limited to [-PX_MAX_BOUNDS_EXTENTS, PX_MAX_BOUNDS_EXTENTS range]. (Previously unbounded).</li>
+            </ul>
+        </ul>
+
+        <h3>Particles</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Setting PxParticleReadDataFlag::eREST_OFFSET_BUFFER 
+on a PxParticleBase instance that was not created with the per particle 
+rest offset option (see PxPhysics::createParticleSystem, 
+PxPhysics::createParticleFluid and 
+PxParticleBaseFlag::ePER_PARTICLE_REST_OFFSET) is not supported. The 
+unsupported configuration may have resulted in crashes. The SDK now 
+rejects this configuration on calling 
+PxParticleBase::setParticleBaseFlag and issues an appropriate warning to
+ the error stream.</li>
+                <li>Performance improvements on Kepler and above GPUs running SPH.</li>
+                <li>In rare cases particle systems could access released memory when all interactions with a rigid body shape were lost.</li>
+            </ul>
+        </ul>
+
+        <h3>Serialization</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxBinaryConverter::convert potentially failed in 
+checked mode with allocators that don't set 0xcd pattern. This has been 
+fixed now.</li>
+            </ul>
+        </ul>
+
+    </blockquote>
+
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.3.1</h1>
+    <h2 style="TEXT-ALIGN: center">December 2013</h2>
+
+    <h2>Supported Platforms</h2>
+    <blockquote>
+        <h3>Runtime</h3>
+        <ul>
+            <li>Apple iOS</li>
+            <li>Apple Mac OS X</li>
+            <li>Google Android (version 2.2 or later for SDK, 2.3 or later required for samples)</li>
+            <li>Linux (tested on Ubuntu)</li>
+            <li>Microsoft Windows XP or later (NVIDIA Driver version R304 or later is required for GPU acceleration)</li>
+            <li>Microsoft Windows RT (formerly known as Windows on ARM) (SDK only, no samples yet)</li>
+            <li>Microsoft XBox One</li>
+            <li>Microsoft XBox 360</li>
+            <li>Nintendo Wii U</li>
+            <li>Sony Playstation 3</li>
+            <li>Sony Playstation 4 (SDK only, no samples)</li>
+            <li>Sony Playstation Vita</li>
+        </ul>
+        <h3>Development</h3>
+        <ul>
+            <li>Microsoft Windows XP or later</li>
+            <li>Microsoft Visual Studio 2008, 2010, 2012 (Windows RT only)</li>
+            <li>Xcode 4.6|5.0|5.0.1</li>
+        </ul>
+    </blockquote>
+    <h2>Known Issues</h2>
+    <blockquote>
+        <ul></ul>
+    </blockquote>
+    <h2>Changes and Resolved Issues</h2>
+    <blockquote>
+
+        <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+        <h3>General</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>The friction model can now be changed after scene 
+instantiation with PxScene::setFrictionType.  The friction model can 
+also be queried with PxScene::getFrictionType.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>PxDefaultSimulationFilterShader now supports particles and cloth as well.</li>
+                <li>PxSimulationFilterCallback: the provided actor and 
+shape pointers are now defined as const. Note: this is no behavior 
+change, it was never allowed to write to those objects from within the 
+callback.</li>
+                <li>The PxTriangleMeshFlag::eHAS_16BIT_TRIANGLE_INDICES 
+and PxTriangleMeshFlag::eHAS_ADJACENCY_INFO enums have been deprecated. 
+Please use PxTriangleMeshFlag::e16_BIT_INDICES and 
+PxTriangleMeshFlag::eADJACENCY_INFO instead.</li>
+                <li>Removed following functions from the API for 
+platforms which do not support CUDA: PxGetSuggestedCudaDeviceOrdinal, 
+PxCreateCudaContextManager, PxLoadPhysxGPUModule.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Fixed concurrency issue on windows. Calling 
+PxScene::simulate on multiple scenes concurrently may have caused a 
+deadlock. This only happened if the scenes shared a single 
+PxCpuDispatcher and the dispatcher was configured to use one worker 
+thread only.</li>
+            </ul>
+        </ul>
+
+        <h3>Rigid Bodies</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>The projection direction for constraints can now be 
+specified through the flags PxConstraintFlag::ePROJECT_TO_ACTOR0, 
+::ePROJECT_TO_ACTOR1.</li>
+                <li>A parameter has been added to 
+PxRigidBodyExt::updateMassAndInertia() and ::setMassAndUpdateInertia() 
+to optionally take non-simulation shapes into account for computing the 
+mass and the inertia tensor of a rigid body.</li>
+                <li>It is now possible to retrieve additional 
+information in contact reports. See the API documentation of 
+PxContactPairHeader.extraDataStream, PxPairFlag::ePRE_SOLVER_VELOCITY, 
+::ePOST_SOLVER_VELOCITY, ::eCONTACT_EVENT_POSE for details.</li>
+                <li>The contact report system has been extended to 
+support multiple notification events if the same two objects collide 
+multiple times in multipass CCD scenarios. See the API documentation of 
+PxPairFlag::eNOTIFY_TOUCH_CCD for details.</li>
+            </ul>
+
+            <li>Changed:</li>
+            <ul>
+                <li>If touching objects were added to the scene asleep 
+and one of them got woken up, then all contact pairs of the touching 
+objects which contained a static rigid body were resolved with a delay 
+of one simulation step. Now these pairs get resolved without delay in 
+the next simulation step.</li>
+                <li>If touching objects were added to the scene asleep, 
+eNOTIFY_TOUCH_FOUND contact reports were sent out for pairs of dynamic 
+rigid bodies if requested. These reports will not be sent at the end of 
+the simulation step after insertion anymore but rather at the end of the
+ simulation step after the touching objects have been woken up.</li>
+                <li>Rigid bodies now permit zeroes in passed to setMass 
+and setMassSpaceInertiaTensor. Zeroes are interpreted to indicate 
+infinite mass or infinite moment of inertia around a given principal 
+axis of inertia. Previously, zeroes were illegal values to these 
+methods. Note that zeroes are still illegal for instances of 
+PxArticulationLink.</li>
+            </ul>
+
+            <li>Fixed:</li>
+            <ul>
+                <li>Reading back the kinematic target in the 
+PxSimulationEventCallback::onContact() callback through 
+PxRigidDynamic::getKinematicTarget() will now work.</li>
+                <li>Contact reports are no longer generated for contact 
+pairs involving two sleeping kinematic actors or for pairs involving a 
+sleeping kinematic actor in contact with a static actor.  This fixes a 
+bug that was introduced in 3.3.0. </li>
+                <li>No PxPairFlag::eNOTIFY_TOUCH_LOST event was sent in 
+contact reports if a pair of sleeping rigid bodies got woken up after 
+setting the pose on one of them (with autowake parameter set to false) 
+and if the bounding boxes of the two objects still overlapped.</li>
+                <li>No PxPairFlag::eNOTIFY_TOUCH_PERSISTS event was sent
+ in contact reports during the first simulation step after a pair of 
+sleeping rigid bodies got woken up.</li>
+                <li>The inertia tensor computation for convex meshes has
+ been adjusted to be more stable in certain cases where floating point 
+precision issues arise. Furthermore, a fallback routine has been added 
+to use an approximation if the diagonalized inertia tensor still ends up
+ with invalid entries.</li>
+                <li>PxRigidBody::clearForce() and ::clearTorque() did 
+not properly clear the respective properties if used with force mode 
+PxForceMode::eIMPULES or PxForceMode::eVELOCITY_CHANGE.</li>
+                <li>Setting PxSceneFlag::eENABLE_KINEMATIC_STATIC_PAIRS also enabled PxSceneFlag::eENABLE_KINEMATIC_PAIRS internally and vice versa.</li>
+                <li>Missing validation checks for some joint set() 
+methods have been added. Similarly to other API calls, when validation 
+fails in the checked build PhysX will report an error and return without
+ updating the joint.</li>
+                <li>Switching a kinematic rigid body to dynamic could 
+lead to a crash in a subsequent simulation step, if the kinematic was 
+moved and connected to another kinematic through a breakable 
+PxConstraint/PxJoint.</li>
+                <li>Deleting a breakable PxConstraint/PxJoint while the 
+simulation is running could lead to a crash if the PxConstraint/PxJoint 
+broke in the same simulation step.</li>
+                <li>A bug in the PxScene::addBroadPhaseRegion() 
+function, that could lead to a crash when using 'populateRegion=true', 
+has been fixed.</li>
+            </ul>
+        </ul>
+
+        <h3>Particles</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>Added triangle mesh cache statistics for GPU 
+particles.  Triangle mesh cache statistics are also captured by PVD as 
+part of simulation statistics.</li>
+                <li>Added new option to query approximate particle 
+velocities relative to colliding rigid actors.  This can be used for 
+debris rotation on moving objects.  Enable with 
+PxParticleReadDataFlag::eCOLLISION_VELOCITY_BUFFER and read from 
+PxParticleReadData::collisionVelocityBuffer.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>Fixed a bug which might lead to GPU particle pipeline failures on low end GPUs.</li>
+                <li>Enabled warning when a spatial data structure overflow occured for GPU particles (see the guide for more information).</li>
+            </ul>
+        </ul>
+
+        <h3>Cloth</h3>
+        <ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxFilterFlag::eSUPPRESS was ignored for collision 
+pairs that involved a PxCloth object. This does work now, however, 
+please note that PxFilterFlag::eSUPPRESS is treated as 
+PxFilterFlag::eKILL for pairs with a PxCloth object.</li>
+            </ul>
+        </ul>
+
+        <h3>Serialization</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>Support for binary compatibility between different 
+sdk releases and patches has been added (PX_BINARY_SERIAL_VERSION). The 
+current sdk version can load binary data of the older sdk versions 
+listed in the documentation of PX_BINARY_SERIAL_VERSION. </li>
+                <li>SnippetLoadCollection has been added. It illustrates
+ loading repx or binary serialized collections and instatiating the 
+objects in a scene. It only compiles and runs on authoring platforms 
+(windows, osx and linux). </li>
+                <li>SnippetConvert has been added. It illustrates how to
+ convert PhysX 3 serialized binary files from one platform to another. 
+It only compiles and runs on authoring platforms (windows, osx and 
+linux). </li>
+            </ul>
+            <li>Deprecated:</li>
+            <ul>
+                <li>Method PxCollection::addRequire is deprecated, use PxCollection::add and PxCollection::contains instead. </li>
+                <li>Method 
+PxCollection::createBinaryConverter(PxSerializationRegistry&amp;) is 
+deprecated, use PxCollection::createBinaryConverter() instead. </li>
+            </ul>
+        </ul>
+
+        <h3>Character controller</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>PxControllerManager::setPreventVerticalSlidingAgainstCeiling()
+ has been added, to control the behaviour of characters against 
+ceilings.</li>
+            </ul>
+        </ul>
+
+
+        <h3>Vehicles</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>Vehicles may now be updated concurrently through the
+ addition of a new function PxVehiclePostUpdates and passing a 
+PxVehicleConcurrentUpdateData array to PxVehicleupdates.</li>
+                <li>A new snippet SnippetVehicleMultiThreading has been added to show the operation of concurrent vehicle updates.</li>
+                <li>PxVehicleDriveTankControl and PxVehicleDriveTankControlModel now have improved doxy comments.</li>
+                <li>A new function PxVehicleUpdateCMassLocalPose has 
+been added to help update a vehicle after the center of mass pose of the
+ vehicle's actor has been modified.</li>
+                <li>PxWheelQueryResult now records the local pose of the wheel.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>PxVehcicleDrive4W::setup now tests that at least 4 
+wheels are specified and returns wtih an error message if numWheels &lt;
+ 4.  It is only possible to create a PxVehicleDrive4W instance with less
+ than 4 active wheels by disabling wheels after instantiating a 
+4-wheeled car.</li>
+                <li>In debug and checked build configurations 
+PxVehicleComputeSprungMasses now reports whether the sprung masses were 
+successfully computed.   Warnings are passed to the error stream in 
+checked configuration if the function does not complete successfully.  
+Apart from error checking the operation of the function is unchanged.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>The doxy comment describing the default setting for 
+PxVehicleWheelsSimData::setWheelShapeMapping was incorrect.  This now 
+correctly documents the default mapping as 
+PxVehicleWheelsSimData::setWheelShapeMapping(i,i).</li>
+                <li>Suspensions raycasts that start inside geometry are 
+ignored for all geometry types.  Prior to this release this was true for
+ all geometry types except for heightfields and triangle meshes.  This 
+inconsistency has now been fixed so that all geometry types obey the 
+rule that suspension raycasts starting inside geometry are neglected.</li>
+            </ul>
+        </ul>
+
+        <h3>Scene queries</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>Added eMTD flag. If an initial overlap is detected, 
+this flag triggers the sweep to compute the MTD (Minimum Translation 
+Direction), which can be used to de-penetrate the query shape from the 
+shape with which an initial overlap was found. In this case, the 
+distance reported will be negative. This negative distance can be used 
+to scale the reported normal to generate the translation vector required
+ to de-penetrate the query shape. </li>
+                <li>Added PxTriangle::pointFromUV.</li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>A rare ray-capsule intersection bug has been fixed, when the capsule's height is close to zero.</li>
+                <li>A capsule-capsule distance bug has been fixed, when the tested capsules are large and parallel.</li>
+                <li>Raycasts against heightfields now correctly return triangle UVs.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>
+                    PxBatchQuery::raycast, overlap and sweep previously 
+had an incorrect const modifier indicating that these methods were safe 
+to call from multiple threads simultaneously. This has been removed.
+                    Multiple batch queries can still be executed (via 
+PxBatchQuery::execute()) in parallel.
+                </li>
+            </ul>
+        </ul>
+
+        <h3>Cooking</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>PxCookingParams::meshSizePerformanceTradeOff 
+parameter can be used to make the mesh smaller at the expense of reduced
+ simulation and scene query performance (or the other way around).</li>
+                <li>PxCookingParams::meshCookingHint parameter can be 
+used to specify mesh hierarchy construction preference (cooking speed or
+ simulation speed).</li>
+                <li>PxMeshPreprocessingFlag::eDISABLE_CLEAN_MESH 
+disables mesh clean proces. Vertices duplicities are not searched, huge 
+triangles test is not done. Vertices welding is not done. Does speed up 
+the cooking.</li>
+                <li>PxMeshPreprocessingFlag::eDISABLE_ACTIVE_EDGES_PRECOMPUTE
+ disables vertex edge precomputation. Makes cooking faster but slow up 
+contact generation.</li>
+                <li>PxPhysicsInsertionCallback adds the support for 
+inserting cooked triangle mesh or height field directly into PxPhysics 
+without the stream serialization.</li>
+                <li>PxCooking::createTriangleMesh creates triangle mesh and inserts it to PxPhysics without using the stream serialization.</li>
+                <li>PxCooking::createHeightField creates height field and inserts it to PxPhysics without using the stream serialization.</li>
+                <li>PxCooking::validateTriangleMesh validates mesh in separate function before it can be cooked without the mesh cleaning.</li>
+                <li>PxConvexFlag::eCHECK_ZERO_AREA_TRIANGLES checks and 
+removes almost zero-area triangles during the computation of the convex 
+hull.</li>
+                <li>PxCookingParams::areaTestEpsilon triangle area size 
+was added. This epsilon is used for the zero-area test in the 
+computation of the convex hull.</li>
+            </ul>
+            <li>Changed:</li>
+            <ul>
+                <li>PxCooking::computeHullPolygons does now return also vertices used by the polygons. Redundant vertices are removed.</li>
+                <li>PxCooking::cookConvexMesh now returns a PxConvexMeshCookingResult::Enum with additional error information.</li>
+            </ul>
+        </ul>
+
+        <h3>Aggregates</h3>
+        <ul>
+            <li>Added:</li>
+            <ul>
+                <li>PxSceneLimits has a new member variable 
+maxNbAggregates.  Setting this value to a good approximation of the peak
+ number of aggregates will avoid the need for internal run-time 
+allocations that can occur when aggregates are added to the scene. </li>
+            </ul>
+            <li>Fixed:</li>
+            <ul>
+                <li>PxScene::removeActor will auotmatically remove that 
+actor from all PxAggregate instances that contain the removed actor.  
+Likewise, PxScene::removeArticulation will automatically remove all 
+articulation links from all relevant aggregates.  This fix upholds the 
+rule that all actors of an aggregate must be in same scene.</li>
+                <li>The condition of an internal assert that triggered 
+after calling PxScene::addAggregate has been corrected. This assert 
+triggered when an aggregate was added to the scene after removal of all 
+aggregates from the scene.  The operation of the function 
+PxScene::addAggregate is unchanged apart from the asserted condtition.</li>
+            </ul>
+        </ul>
+
+        <h3>Samples</h3>
+        <ul>
+            <li>Changed:</li>
+            <ul>
+                <li>Starting with Release 302 drivers, application 
+developers can direct the Optimus driver at runtime to use the High 
+Performance Graphics to render any application - even those applications
+ for which there is no existing application profile. The samples now 
+make use of this feature to enable High Performance Graphics by default.</li>
+            </ul>
+        </ul>
+    </blockquote>
+
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <br>
+    <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+    <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.3</h1>
+    <h2 style="TEXT-ALIGN: center">September 2013</h2>
+
+    <h2>Release Highlights</h2>
+    <blockquote>
+        <ul>
+            <li>Added PhysXDevice/64.dll to the PC packages. See the Windows readme for details.</li>
+            <li>Added support for the NVIDIA Kepler GPU architecture.</li>
+            <li>Added support for the Nintendo Wii U console.</li>
+            <li>Added support for Windows 8 Modern UI applications (ARM and x86).</li>
+            <li>Ported our SIMD library to the ARM NEON architecture.</li>
+            <li>Multi Box Pruning (MBP) is offered as an alternative 
+broad phase algorithm to Sweep And Prune (SAP). MBP shows improved 
+performance when most objects are moving or when inserting large numbers
+ of objects. SAP can be faster in scenarios with few moving (many 
+sleeping) objects.</li>
+            <li>Significant performance and stability optimizations for rigid body solver.</li>
+            <li>New function to compute the minimum translational distance and direction to separate two overlapping geometry objects.</li>
+            <li>New 'PCM' contact generation mode which is often faster and more robust than the still available legacy path.</li>
+            <li>Improved performance of scene queries and contact reports.</li>
+            <li>Improved behavior and performance of Continuous Collision Detection (CCD).</li>
+            <li>Reduced memory footprint of rigid body classes.</li>
+            <li>Added support for sharing shapes among rigid bodies.</li>
+            <li>Significantly improved cloth behavior and GPU performance.</li>
+            <li>Added support for cloth colliding against itself, other cloth instances, and scene geometry.</li>
+            <li>Improved useability of binary and xml serialization.</li>
+            <li>Memory can be saved for objects that do not participate 
+in the simulation and are used for scene queries only. For details see 
+the new flag PxActorFlag::eDISABLE_SIMULATION.</li>
+        </ul>
+    </blockquote>
+
+    <h2>Supported Platforms</h2>
+    <blockquote>
+        <h3>Runtime</h3>
+        <ul>
+            <li>Apple iOS</li>
+            <li>Apple Mac OS X</li>
+            <li>Google Android (version 2.2 or later for SDK, 2.3 or later required for samples)</li>
+            <li>Linux (tested on Ubuntu)</li>
+            <li>Microsoft Windows XP or later (NVIDIA Driver version R304 or later is required for GPU acceleration)</li>
+            <li>Microsoft Windows RT (formerly known as Windows on ARM) (SDK only, no samples yet)</li>
+            <li>Microsoft XBox One</li>
+            <li>Microsoft XBox 360</li>
+            <li>Nintendo Wii U</li>
+            <li>Sony Playstation 3</li>
+            <li>Sony Playstation 4 (SDK only, no samples yet)</li>
+            <li>Sony Playstation Vita</li>
+        </ul>
+        <h3>Development</h3>
+        <ul>
+            <li>Microsoft Windows XP or later</li>
+            <li>Microsoft Visual Studio 2008, 2010, 2012 (Windows RT/PS4/XboxOne only)</li>
+            <li>Xcode 4.6</li>
+        </ul>
+    </blockquote>
+
+    <h2>Known Issues</h2>
+    <blockquote>
+        <ul>
+            <li>PxSimulationOrder::eSOLVE_COLLIDE feature is not 
+implemented in this release.  Calls to PxScene::solve() and 
+PxScene::collide() will be ignored with a warning added to the error 
+stream</li>
+            <li>Reading back the kinematic target through 
+PxRigidDynamic::getKinematicTarget() in the 
+PxSimulationEventCallback::onContact() callback will fail.</li>
+            <li>Cloth self-collision without rest position is not supported on GPUs with SM capability lower than 2.0.</li>
+        </ul>
+    </blockquote>
+    <h2>
+        Changes and Resolved Issues</h2>
+        <blockquote>
+
+            <i>Note: Platform specific issues and changes can be found in the readme file of the corresponding platform.</i>
+
+            <h3>General</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>PxScene::setLimits: Hint to preallocate capacities of various data structures. See PxSceneLimits.</li>
+                    <li>Scalar constructors PxQuat(r), PxMat33(r), PxMat33(r).</li>
+                    <li>identity constructors for PxMat33, PxMat44, PxQuat, PxTransform - e.g. PxTransform(PxIdentity).</li>
+                    <li>zero constructors for PxMat33, PxMat44, PxVec3 - e.g. PxMat33(PxZero).</li>
+                    <li>PxTransform(x, y, z) constructor was added as a shortcut for PxTransform(PxVec3(x,y,z)).</li>
+                    <li>The GPU code uses CUDA version 5.0 and supports Kepler GPUs (SM version 3.0 and 3.5).
+                    </li><li>Helper method PxContactPair::bufferContacts() has been added to copy the contact pair data stream into a user buffer.</li>
+                    <li>PxGeometryQuery::computePenetration() has been added, to compute the Minimum Translational Distance between geometry objects.</li>
+                    <li>Ability for APEX and other PhysX extensions to change the PhysX Visual Indicator.</li>
+                    <li>Reporting allocation names can now be enabled or
+ disabled (see PxFoundation::setReportAllocationNames). When enabled, 
+some platforms allocate memory through 'malloc'.</li>
+                    <li>The scene origin can now be shifted to better support big world scenarios. See PxScene::shiftOrigin() for details.</li>
+                    <li>PxAssertHandler got extended with a boolean 
+parameter to support ignoring specific asserts. See windows 
+implementation of DefaultAssertHandler.</li>
+                    <li>Added new PxPairFlags - PxPairFlag::eSOLVE_CONTACT and PxPairFlag::eDETECT_DISCRETE_CONTACT.</li>
+                </ul>
+                <li>Removed:</li>
+                <ul>
+                    <li>The obsolete PxConvexFlag::eUSE_UNCOMPRESSED_NORMALS flag has been removed.</li>
+                    <li>The PxSceneFlag::eDISABLE_SSE was obsolete, and has now been removed.</li>
+                    <li>The obsolte PxPtrArray has been removed</li>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>Mesh BVH construction was significantly improved
+ for meshes with a mix of large and small triangles. Mesh sizes are now 
+slightly increased, but traversals are substantially faster. As a side 
+effect, cooked mesh format has changed. This requires meshes to be 
+recooked!</li>
+                    <li>The specification for valid PxBounds3 
+representations has changed. See the API documentation for details 
+(especially the newly introduced PxBounds3::isValid() method).</li>
+                    <li>PxBounds3::transform(), ::scale() and ::fatten()
+ have been split into a fast and a safe version to avoid unnecessary 
+checks and improve stability for empty bounds respectively.</li>
+                    <li>PxBounds3::setInfinite() has been renamed to PxBounds3::setMaximal() to better fit the actual behavior.</li>
+                    <li>PxTask: PVD profile events for tasks are now only emitted in profile builds (all platforms).</li>
+                    <li>Platform mutex implementations now verify that lock/unlock come from correct thread in debug builds.</li>
+                    <li>PxWindowsDelayLoadHook.h has been moved from Include/foundation/windows to Include/common/windows.</li>
+                    <li>API instances of 'Num' as in 'maxNum' and 'getNum' have changed uniformly to 'Nb'.</li>
+                    <li>
+                        The following classes have been renamed:
+                        <ul>
+                            <li>PxSceneQueryHit to PxQueryHit</li>
+                            <li>PxSceneQueryFlags to PxHitFlags</li>
+                            <li>PxSceneQueryHitType to PxQueryHitType</li>
+                            <li>PxSceneQueryFilterData to PxQueryFilterData</li>
+                            <li>PxSceneQueryFilterCallback to PxQueryFilterCallback</li>
+                            <li>PxSceneQueryFilterFlags to PxQueryFlags</li>
+                            <li>PxSceneQueryCache to PxQueryCache</li>
+                            <li>PxCCTNonWalkableMode to PxControllerNonWalkableMode</li>
+                            <li>PxControllerFlags to PxControllerCollisionFlags</li>
+                            <li>PxCCTHit to PxControllerHit</li>
+                            <li>PxConstraintDominance to PxDominanceGroupPair</li>
+                            <li>PxActorTypeSelectionFlags to PxActorTypeFlags</li>
+                            <li>PxFindOverlapTriangleMeshUtil to PxMeshOverlapUtil</li>
+                        </ul>
+                        The previous names have been retained for compatibility but are deprecated.
+                    </li>
+                    <li>PX_SLEEP_INTERVAL has been replaced with the new
+ parameter PxSceneDesc::wakeCounterResetValue to specify the wake 
+counter value to set when wakeUp() gets called on dynamic objects.</li>
+                    <li>PxClientBehaviorBit has been renamed 
+PxClientBehaviorFlag, PxActorClientBehaviorBit has been renamed 
+PxActorClientBehaviorFlag. Names of related functions have also changed.</li>
+                    <li>queryClient parameter in raycast(), sweep(), overlap() functions was moved inside of PxQueryFilterData struct.</li>
+                    <li>The PxObserver/PxObservable system has been 
+replaced by the PxDeletionListener API. The supported object types have 
+been extended from PxActor to all core objects inheriting from PxBase. 
+Furthermore, two kinds of deletion events are now distinguished: user 
+release and memory release. Please read the API documentation for 
+details.</li>
+                    <li>Deprecated PxPairFlag::eRESOLVE_CONTACT. Use PxPairFlag::eDETECT_DISCRETE_CONTACT and PxPairFlag::eSOLVE_CONTACT instead.</li>
+                    <li>Number of materials per shape is now PxU16 instead of PxU32, contact material information also now returns PxU16.</li>
+                    <li>Maximum number of touching hits in batched queries is now PxU16 instead of PxU32.</li>
+                    <li>SweepEpsilonDistance has been replaced by 
+meshContactMargin and marked as deprecated. Please read the API 
+documentation for details.</li>
+                    <li>PxShape::resetFiltering() and 
+PxParticleBase::resetFiltering() have been deprecated. Please use one of
+ the new overloaded methods PxScene::resetFiltering() instead.</li>
+                    <li>The pxtask namespace has been removed and it's types have been added to the physx namespace with a Px* prefix</li>
+                    <li>The delay load hook 
+PxDelayLoadHook::setPhysXInstance has been renamed to 
+PxSetPhysXDelayLoadHook and PxDelayLoadHook::setPhysXCookingInstance has
+ been renamed to PxSetPhysXCookingDelayLoadHook</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Calling Thread::setAffinityMask() before the thread has been started is now supported.</li>
+                    <li>PxDefaultSimulationFilterShader ignored the 
+value of the second filter constant in the collision filtering equation 
+and used the value of the first filter constant instead.</li>
+                </ul>
+                <li>Deprecated:</li>
+                <ul>
+                    <li>The PxScene::flush() method has been deprecated, please use PxScene::flushSimulation().</li>
+                    <li>PxRigidDynamicFlag has been deprecated and 
+replaced with PxRigidBodyFlag to allow flags to be shared between 
+PxArticulationLink and PxRigidDynamic.</li>
+                    <li>PxTransform::createIdentity(), 
+PxQuat::createIdentity(), PxMat33::createIdentity(), 
+PxMat44::createIdentity(), PxMat33::createZero(), PxMat44::createZero()</li>
+                </ul>
+            </ul>
+
+            <h3>Character controller</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>The PxControllerBehaviorFlag::eCCT_USER_DEFINED_RIDE flag has been added.</li>
+                    <li>A new helper function PxController::resize() has been added to facilitate character controller resizing.</li>
+                    <li>A new runtime tessellation feature has been added that can help reducing FPU accuracy issues in the sweep tests.</li>
+                    <li>PxControllerFilterCallback has been added to make CCT-vs-CCT filtering more flexible.</li>
+                    <li>An overlap recovery module has been added. See PxControllerManager::setOverlapRecoveryModule</li>
+                    <li>PxObstacle notifications has been added to handle touched obstacles.</li>
+                    <li>PxObstacleContext::getObstacleByHandle has been added.</li>
+                    <li>The origin of character controllers and 
+obstacles can now be shifted to stay in sync when the origin of the 
+underlying PxScene is shifted. See PxControllerManager::shiftOrigin() 
+for details.</li>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>The PxControllerManager is now tightly coupled 
+to a PxScene which has to be provided on creation. See 
+PxCreateControllerManager().</li>
+                    <li>The PxObstacleContext instances of a PxControllerManager will now get released automatically when the manager is released.</li>
+                    <li>PxController::reportSceneChanged() has been renamed to PxController::invalidateCache().</li>
+                    <li>PxControllerBehaviorFlag::eCCT_CAN_RIDE_ON_OBJECT is not the default behavior anymore.</li>
+                    <li>PxCCTNonWalkableMode::eFORCE_SLIDING has been renamed to PxCCTNonWalkableMode::ePREVENT_CLIMBING_AND_FORCE_SLIDING.</li>
+                    <li>PxCCTInteractionMode has been renamed PxControllerInteractionMode</li>
+                    <li>PxCCTNonWalkableMode has been renamed PxControllerNonWalkableMode</li>
+                    <li>PxCCTHit has been renamed PxControllerHit</li>
+                    <li>Touched PxObstacle has been replaced by touched ObstacleHandle.</li>
+                    <li>PxControllerInteractionMode and 
+PxControllerFilters::mActiveGroups have been removed. Please use the new
+ PxControllerFilterCallback instead.</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Bugs with respect to deleting shapes from a touching actor have been fixed.</li>
+                    <li>Touched actor's scene is checked in CCT::move before rideOnTouchedObject is called to ensure that the touched shape is valid.</li>
+                    <li>Touched shape's scene query flag is checked in 
+CCT::move before rideOnTouchedObject is called to ensure that the 
+touched shape is valid.</li>
+                    <li>Touched shape's user CCT filtering is triggered 
+in CCT::move before rideOnTouchedObject is called to ensure that the 
+touched shape is valid.</li>
+                    <li>The PxControllerBehaviorCallback was not called when a PxUserControllerHitReport was not defined.</li>
+                    <li>It is not possible anymore to create a CCT whose
+ contact offset is zero. The doc has always said a non-zero value was 
+expected, but corresponding check was missing.</li>
+                    <li>Box &amp; capsule controllers' resize function now properly take the up direction into account</li>
+                </ul>
+            </ul>
+
+            <h3>CCD</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>Introduced PxRigidBodyFlag::eENABLE_CCD_FRICTION
+ to control whether friction is applied inside CCD on a given body. This
+ is disabled by default. In general, disabling friction in CCD improves 
+the behavior of high-speed collisions.</li>
+                    <li>Introduced PxSceneDesc::ccdMaxPasses field, 
+which controls the maximum number of CCD passes. Each CCD pass will 
+advance each object to its next TOI. By default, we use 1 pass. 
+Increasing the number of passes can reduced the likelihood of time being
+ dropped inside the CCD system at the cost of extra CCD procesing 
+overhead.</li>
+                    <li>Introduced per-body value to control how far 
+past the initial time of impact the CCD advances the simulation. 
+Advancing further can improve fluidity at the increased risk of 
+tunneling.</li>
+                    <li>CCD now has limited support contact 
+modification. It supports disabling response to contacts by setting max 
+impulse to 0. It does not yet support target velocity, non-zero max 
+impulse values or scaling mass or inertia.</li>
+                    <li>Introduced new PxPairFlag eDETECT_CCD_CONTACT. 
+This flags is used to control whether CCD performs sweep tests for a 
+give pair. Decision over whether any collisions are responded to is made
+ by the presence of the flag eSOLVE_CONTACT.</li>
+                </ul>
+                <li>Removed:</li>
+                <ul>
+                    <li>CCD is now enabled per-body instead of 
+per-shape. As a result, PxShapeFlag::eUSE_SWEPT_BOUNDS has been removed 
+and replaced with PxRigidBodyFlag::eENABLE_CCD.</li>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>API attributes previously named 
+SWEPT_INTEGRATION have now been renamed 'ccd': specifically 
+PxSceneFlag::eENABLE_SWEPT_INTEGRATION, 
+PxSceneFlag::eSWEPT_INTEGRATION_LINEAR, 
+PxSceneDesc::sweptIntegrationLinearSpeedFactor, 
+PxSceneDesc::sweptIntegrationAngularSpeedFactor, 
+PxPairFlag::eENABLE_SWEPT_INTEGRATION</li>
+                    <li>PxPairFlag::eCCD_LINEAR has been deprecated. Use (PxPairFlag::eDETECT_CCD_CONTACT | PxPairFlag::eSOLVE_CONTACT) instead.</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Updated CCD algorithm which improves the 
+fluidity of motion of the CCD system while reducing the processing 
+overhead significantly.</li>
+                    <li>Contact notification is now reliable in CCD. CCD
+ contacts are appended to the end of the contact list for a given pair 
+so that both discrete and continuous contacts are reported</li>
+                    <li>CCD contact notification now reports applied forces. These contacts will be correctly filtered by force thresholds.</li>
+                </ul>
+            </ul>
+
+            <h3>Serialization</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>Added extension PxSerialization::isSerializable method to query whether a collection is serializable.</li>
+                    <li>Added extension PxSerialization::complete which allows to prepare a collection for serialization.</li>
+                    <li>Added extension PxSerialization::createNames which adds reference names to serializables.</li>
+                    <li>Added extension PxCollectionExt::remove which 
+removes all serializables of a certain type and optionally adds them to 
+another collection.</li>
+                    <li>Added extension function PxCollectionExt::releaseObjects to remove and release objects from a collection</li>
+                    <li>Added class PxSerializationRegistry for handling custom serializable types.</li>
+                    <li>Added PxSerialization::serializeCollectionToXml and PxSerialization::createCollectionFromXml</li>
+                    <li>Included pre-built binary meta data with SDK at [path to installed PhysX SDK]/Tools/BinaryMetaData</li>
+                    <li>Added class PxSerializer to provide serialization specific functionality to serializable classes.</li>
+                    <li>Added classes PxSerializationContext and 
+PxDeserializationContext to provide functionality for serialization and 
+deserialization operations.</li>
+                </ul>
+                <li>Removed:</li>
+                <ul>
+                    <li>Removed PxUserReferences class and PxPhysics::createUserReferences.</li>
+                    <li>Removed RepX.h and unified serialization interfaces for xml and binary serialization.</li>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>PxCollection was reworked to improve reference 
+management rendering PxUserReferences obsolete. PxCollection was also 
+decoupled more from Serialization/Deserialization functionality. 
+Serialization of incomplete collections fails now early at serialization
+ as opposed to late at deserialization.</li>
+                    <li>Replaced PxPhysics::createCollection with PxCreateCollection.
+                    </li><li>
+                    </li><li>Replaced RepXCollection with PxCollection, and unified corresponding interfaces.</li>
+                    <li>Replaced PxCollection::serialize with PxSerialization::serializeCollectionToBinary.</li>
+                    <li>Replaced PxCollection::deserialize with PxSerialization::createCollectionFromBinary.</li>
+                    <li>Replaced 
+PxSerializable::collectForExport(PxCollection&amp; c) with 
+PxSerializer::requires. The new method works in a non-recursive way.</li>
+                    <li>Replaced PxDumpMetaData with PxSerialization::dumpMetaData.</li>
+                    <li>Replaced PxCollectForExportSDK with PxCollectionExt::createCollection(PxPhysics&amp; sdk).</li>
+                    <li>Replaced PxCollectForExportScene with PxCollectionExt::createCollection(PxScene&amp; scene).</li>
+                    <li>Moved PxCooking::createBinaryConverter to PxSerialization</li>
+                    <li>Changed PxShape release semantics for shapes. As
+ a consequence deserialized shapes are never autmatically released, but 
+need to be released by the application. Exception: PxPhysics::release.</li>
+                </ul>
+            </ul>
+
+            <h3>Cloth</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>Improved GPU cloth performance significantly with new parallel solver.</li>
+                    <li>Added tether constraints, which allow minimum amount of cloth stretching even for large gravity scales. See PxClothFabric.</li>
+                    <li>Added support for dynamic addition and deletion 
+of collision primitives.  See PxCloth::addCollision* and 
+PxCloth::removeCollision*.</li>
+                    <li>Added triangle mesh collider support. See PxCloth::setCollisionTriangles. </li>
+                    <li>Added support for self collision and inter-cloth
+ collision. See PxCloth::setSelfCollision*() and 
+PxScene::setClothInterCollision*().</li>
+                    <li>Added direct access to CUDA particle data for graphics interoperability, see PxCloth::lockParticleData()</li>
+                    <li>Added PxRegisterCloth to reduce binary size by stripping unused code on platforms where static linking is used.</li>
+                    <li>Added methods setWakeCounter/getWakeCounter() (see the corresponding API documentation for details).</li>
+                    <ul>
+                        <li>It is illegal to call wakeUp/putToSleep/isSleeping() on a PxCloth that has not been added to a scene.</li>
+                    </ul>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>Cloth solver does not use fibers any more. See PxClothFabric for changes in fabric API.</li>
+                    <li>Moved PxCooking.cookClothFabric() to extensions. See PxClothFabricCooker and PxClothFabricCreate.</li>
+                    <li>PxClothMeshDesc has been moved to extensions and now supports both triangle and quad representations.  See PxClothMeshDesc.</li>
+                    <li>The scaling of damping and stiffness 
+coefficients has been separated from the solver frequency and can now be
+ set indepedently using PxCloth::setStiffnessFrequency().</li>
+                    <li>PxCloth::setInertiaScale() has been split into linear, angular, and centrifugal components.  See PxCloth::set*IntertiaScale.</li>
+                    <li>Drag coefficient has been split into linear and 
+angular coefficient. See PxCloth::setLinearDragCoefficient and 
+PxCloth::setAngularDragCoefficient.</li>
+                    <li>Renamed PxCloth::lockClothReadData() to 
+lockParticleData().  Added support for update operations on the returned
+ particle arrays (as an alternative to setParticles()).</li>
+                    <li>PxCloth::wakeUp() does not have a parameter anymore. Use setWakeCounter() instead to set a specific value.</li>
+                    <li>PxCloth::getNbCollisionSpherePairs() has been renamed to PxCloth::getNbCollisionCapsules()</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Fixed a crash bug in the clothing collision code appearing on iOS.</li>
+                </ul>
+            </ul>
+
+            <h3>Rigid Bodies</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>The contact distance parameter for a limit is 
+automatically estimated if not supplied in the constructor for the limit
+ structure.</li>
+                    <li>The new callback 
+PxConstraintConnector::onOriginShift() has been introduced. It gets 
+called for all constraints of a scene, when its origin is shifted.</li>
+                    <li>New helper function PxRigidBodyExt::computeVelocityDeltaFromImpulse has been added.</li>
+                    <li>Shapes may be declared as shared on creation, and then attached to multiple actors, see the user manual for restrictions.</li>
+                    <li>
+                        Since a shape is no longer necessarily 
+associated with a unique actor, references to shapes in callbacks from 
+the engine are accompanied by the
+                        a reference to the associated actor
+                    </li>
+                    <li>Joints and contact modification now support 
+tuning relative mass and inertia for the bodies on a per-contact basis. 
+Inertia and mass can be tuned independently.</li>
+                </ul>
+                <li>Removed:</li>
+                <ul>
+                    <li>PxShape::overlap(), PxShape::sweep() and 
+PxShape::raycast() have been removed. Equivalent functionality is 
+provided in PxGeometryQuery.</li>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>It is illegal to call resetFiltering() on a PxShape or PxParticleBase if they have not been added to a scene.</li>
+                    <li>It is illegal to call addForce/addTorque/clearForce/clearTorque() on a PxRigidBody that has not been added to a scene.</li>
+                    <li>
+                        The sleep behavior of dynamic rigid bodies has 
+changed significantly (for details on the current behavior see the API 
+documentation of isSleeping(), wakeUp(), putToSleep(), 
+setKinematicTarget(), PxRigidBodyFlag::eKINEMATIC, ...). Among the 
+changes are:
+                        <ul>
+                            <li>The methods 
+setWakeCounter/getWakeCounter() have been added for PxRigidDynamic and 
+PxArticulation objects (see the corresponding API documentation for 
+details).</li>
+                            <li>The wakeUp() method of PxRigidDynamic 
+and PxArticulation has lost the wake counter parameter. Use 
+setWakeCounter() instead to set a specific value.</li>
+                            <li>It is illegal to call wakeUp/putToSleep/isSleeping() on a PxRigidDynamic or PxArticulation that has not been added to a scene.</li>
+                            <li>Putting a dynamic rigid actor to sleep will clear any pending force updates.</li>
+                            <li>Switching a dynamic actor to kinematic will put the actor to sleep immediately.</li>
+                            <li>Switching a kinematic actor back to dynamic will not affect the sleep state (previously the actor was woken up).</li>
+                            <li>Calling wakeUp/putToSleep() on a 
+kinematically controlled dynamic actor is not valid any longer. The 
+sleep state of a kinematic actor is solely defined based on whether a 
+target pose has been set (see API documentation of isSleeping() for 
+details).</li>
+                            <li>A call to 
+PxRigidBody::setCMassLocalPose() does not wake up the actor anymore. 
+Note: this also affects related methods in PhysXExtensions like 
+PxRigidBodyExt::updateMassAndInertia() etc.</li>
+                            <li>If a non-zero velocity or force is set 
+through PxRigidBody::setLinearVelocity(), ::setAngularVelocity(), 
+::addForce() or ::addTorque(), the actor will get woken up automatically
+ even if the autowake parameter is false.</li>
+                            <li>PxRigidBody::clearForce() and 
+::clearTorque() do not have the autowake parameter, to optionally wake 
+the actor up, anymore. These methods will not change the sleep state any
+ longer. Call ::wakeUp() subsequently to get the old default behavior.</li>
+                            <li>Adding or removing a PxConstraint/PxJoint to/from the scene does not wake the connected actors up automatically anymore.</li>
+                            <li>It is now possible to avoid automatic 
+wake up of previously touching objects on scene removal. See the 
+additional parameter wakeOnLostTouch in PxScene::removeActor(), 
+::removeArticulation(), ::removeAggregte(), PxRigidActor::detachShape().</li>
+                        </ul>
+                    </li>
+                    <li>PxJointLimit and PxJointLimitPair are now 
+PxJointLinearLimit, PxJointLinearLimitPair, PxJointAngularLimitPair, 
+depending on whether the limit is linear or angular.</li>
+                    <li>Joints now solve for the entire position error 
+rather than a ratio of 0.7 of it. The flag 
+PxConstraintFlag::eDEPRECATED_32_COMPATIBILITY can be used to restore 
+this behavior</li>
+                    <li>PxConstraintFlag::Type has been renamed to PxConstraintFlag::Enum
+                    </li><li>
+                    </li><li>The spring constant parameter in joints and articulations that was previously 'spring' is now 'stiffness'.</li>
+                    <li>The tangential spring constant parameter in articulations that was previously 'tangentialSpring' is now 'tangentialStiffness'.</li>
+                    <li>Constraints do not respect PxDominanceGroup settings. Use PxJoint::setInvMassScale and setInvInertiaScale</li>
+                    <li>Shapes are reference counted. PxShape::release()
+ now decrements the reference count on a shape, and its use is 
+deprecated for detaching a shape from its actor - use detachShape() 
+instead.</li>
+                    <li>Shape creation methods do not take a local 
+transform parameter anymore. Instead PxShapeFlags can be specified. 
+Triangle meshes, height fields and plane geometry shapes cannot be 
+combined with non-kinematic PxRigidDynmic actors if 
+PxShapeFlag::eSIMULATION_SHAPE is specified. Corresponding calls to 
+PxRigidActor::createShape() or PxRigidActor::attachShape() are not 
+supported.</li>
+                    <li>PxShape::getActor() now returns a pointer, which is NULL if the shape is shareable.</li>
+                    <li>PxShape::getWorldBounds() has been replaced with PxShapeExt::getWorldBounds().</li>
+                    <li>PxContactPoint has been renamed PxFeatureContact.</li>
+                    <li>The internal format for contact storage has been
+ modified; applications directly accessing the internal contact 
+representation rather than PxContactPair::extractContacts should be 
+modified accordingly.</li>
+                    <li>Friction mode flags 
+eENABLE_ONE_DIRECTIONAL_FRICTION and eENABLE_TWO_DIRECTIONAL_FRICTION 
+have been replaced by PxFrictionType::Enum PxSceneDesc::frictionType.</li>
+                    <li>PxSceneDesc::contactCorrelationDistance has been deprecated.</li>
+                    <li>PxSceneDesc::contactCorrelationDistance no 
+longer has an influence on how many friction anchors are created in a 
+single frame, only on when they are removed in later frames.  This may 
+cause a very minor change in friction behavior.</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Rigid bodies now properly accumulate the 
+forces/torques that are applied with addForce/addTorque while scene 
+insertion is still pending.  This affects bodies added to the scene 
+while the scene is simulating and then given forces/torques with 
+addForce/addTorque while the scene is simulating.  These accumulated 
+forces and torques are applied during the next simulate() call.  Prior 
+to this fix the forces/torques that accumulated while scene insertion 
+was pending were lost and never applied.</li>
+                    <li>Its now possible to serialize collections with 
+jointed actors without including the corresponding joints in the 
+collection. The deserialized actors will not be jointed anymore.</li>
+                    <li>Joint drive force limits are actual force limits
+ rather than impulse limits. Set the flag 
+PxConstraintFlag::eDRIVE_LIMITS_ARE_FORCES to false to support legacy 
+behavior</li>
+                    <li>Angular drive constraints for revolute joints 
+were wrongly computed, resulting in a negative angular velocity when a 
+positive drive target was set.</li>
+                    <li>Scene addActors will now correctly remove all actors that were passed to add, if some insert failed.</li>
+                    <li>Contact modification now enforces max impulse field correctly. Previously, it only enforced it if max impulse was set to 0.</li>
+                    <li>Contact modification now supports target 
+velocity in all directions. Previously, it only enforced the target 
+velocity components that were perpendicular to the contact normal.</li>
+                    <li>Jittering of small spheres &amp; capsules on very large triangles has been fixed.</li>
+                    <li>Setting sleep threshold to 0 now guarantees that bodies won't fall asleep even if their kinetic energy reaches exactly 0.</li>
+                </ul>
+                <li>Deprecated:</li>
+                <ul>
+                    <li>PxShape::release() now decrements the reference 
+count on a shape, and its use is deprecated for detaching a shape from 
+its actor - use detachShape() instead.</li>
+                    <li>PxJoint::getType() is deprecated - use getConcreteType() instead.</li>
+                    <li>PxConstraintFlag::eREPORTING is deprecated - constraints always generate force reports</li>
+                    <li>PxConstraintDominance is deprecated - use PxDominanceGroupPair instead.</li>
+                </ul>
+            </ul>
+
+            <h3>Scene queries</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>PxVolumeCache, a volumetric cache for local collision geometry.</li>
+                    <li>Parameter inflation was added to some PxGeometryQuery functions.</li>
+                    <li>Flag eMESH_BOTH_SIDES can be now used to control triangle mesh culling for raycasts and sweeps.</li>
+                    <li>Added PxBatchQueryMemory as a part of PxBatchQueryDesc, to allow memory buffers to be set before execution.</li>
+                    <li>PxBatchQueryDesc() constructor now requires 3 parameters at initialization - see migration guide for more details.</li>
+                    <li>PxBatchQuery::raycast, sweep, overlap calls will now issue a warning and discard the query when over maximum allowed queries.</li>
+                    <li>There is a new flag to allow manually updating 
+the scene query representation, see: 
+PxSceneFlags::eENABLE_MANUAL_SQ_UPDATE and PxScene::flushQueryChanges().</li>
+                    <li>Added PxScene::forceDynamicTreeRebuild() function to immediately rebuild the scene query structures.</li>
+                    <li>Added bool PxSweepHit::hadInitialOverlap() returning true if a sweep hit occurred early due to initial overlap at distance=0.</li>
+                </ul>
+                <li>Removed:</li>
+                <ul>
+                    <li>PxBatchQuery::linearCompoundGeometrySweepSingle 
+and PxBatchQuery::linearCompoundGeometrySweepMultiple functions are no 
+longer supported.</li>
+                    <li>Globals PxPS3ConfigParam::eSPU_OVERLAP, 
+eSPU_RAYCAST, eSPU_SWEEP that were previous set via setSceneParamInt 
+call are replaced with PxBatchQueryDesc::runOnSpu. See migration guide 
+for more details.</li>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>Scene Query raycastAny/Single/Multiple APIs were
+ merged into a single raycast() call (same for overlaps and sweeps). 
+Please refer to user and migration guides for details.</li>
+                    <li>Scene Query raycast() API now uses a 
+PxRaycastBuffer or a PxRaycastCallback parameter for reporting hits. 
+Blocking hits are now reported separately from toching and 
+PxRaycastCallback class supports reporting an unbounded number of 
+results (same for overlaps and sweeps).</li>
+                    <li>A const templated PxRaycastBufferN<int> object was added to allow convenient creation of fixed size scene query touch buffers. Same for overlaps and sweeps.</int></li>
+                    <li>Support for compound sweeps was moved out from core SDK to extensions.</li>
+                    <li>Support for compound sweeps was moved from 
+PxScene to extensions (see PxRigidBodyExt::linearSweepSingle, 
+PxRigidBodyExt::linearSweepMultiple).</li>
+                    <li>PxQueryFilterCallback::preFilter now passes an actor pointer as well as a shape pointer.</li>
+                    <li>PxSceneQueryFlag::eINITIAL_OVERLAP and 
+PxSceneQueryFlag::eINITIAL_OVERLAP_KEEP have been replaced with 
+PxHitFlag::eINITIAL_OVERLAP_DISABLE and 
+PxLocationHit::hadInitialOverlap(). Note that checking for initial 
+overlap is now the defaut for sweeps.</li>
+                    <li>Sweeps in 3.3 execute using a new faster code 
+path, in some cases with reduced precision. If you encounter precision 
+issues not previously experienced in earlier versions of PhysX, use 
+ePRECISE_SWEEP flag to enable the backwards compatible more accurate 
+sweep code.</li>
+                    <li>The default behavior for overlap queries with 
+query filters returning eBLOCK has changed to only return one of eBLOCK 
+hits. Please refer to the migration guide for details.</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Scene Query performance was significantly improved in a variety of scenarios.</li>
+                    <li>Fixed a bug in capsule/mesh overlap code that occasionally caused unreported and misreported faces.</li>
+                    <li>Fixed a crash in raycastMultiple when a convex was hit by the ray and eMESH_MULTIPLE flag was specified as a query flag.</li>
+                    <li>Fixed a rare crash in heightfield raycast code.</li>
+                    <li>Internal limit of 65536 results has been removed.</li>
+                    <li>Accuracy in sphere/capsule-vs-triangle overlap and sweep tests has been improved.</li>
+                </ul>
+            </ul>
+
+            <h3>Cooking</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>Added support for convex hull creation with limited output vertices count.</li>
+                    <li>Added support for convex hull creation directly from polygons rather than triangles.</li>
+                    <li>Added support function computeHullPolygons in 
+cooking, that creates hull polygons from given vertices and triangles. 
+The resulting polygons can be used to create the convex hull directly.</li>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>Changed convex hull volume integrals.</li>
+                    <li>PxCookingParams constructor requires now 
+PxTolerancesScale as an additional parameter. This enables us to perform
+ further checks on the triangles during cooking. A warning will be 
+emitted to the error stream if too huge triangles were found. This will 
+ensure better simulation stability.</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Optimized heightfield load code for no-endian conversion case.</li>
+                </ul>
+            </ul>
+
+            <h3>Triangle meshes</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>Added PxTriangleMeshFlag::eHAS_ADJACENCY_INFO flag for adjacency information checks.</li>
+                </ul>
+                <li>Removed:</li>
+                <ul>
+                    <li>Removed has16BitTriangleIndices(), replaced by 
+triangleMesh-&gt;getTriangleMeshFlags() &amp; 
+PxTriangleMeshFlag::eHAS_16BIT_TRIANGLE_INDICES.</li>
+                </ul>
+            </ul>
+
+            <h3>Particles</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>Direct read access to CUDA particle data has 
+been added for graphics interoperability, see 
+PxParticleBase::lockParticleReadData(PxDataAccessFlags flags) and 
+PxParticleFluid::lockParticleFluidReadData(PxDataAccessFlags flags)</li>
+                    <li>Added PxRegisterParticles to reduce binary size by stipping unused code on platforms where static linking is used.</li>
+                    <li>Added setExplicitCudaFlushCountHint to allow early flushing of the cuda push buffer.</li>
+                    <li>Added caching of triangle meshes. setTriangleMeshCacheSizeHint is supported on Kepler and above GPUs.</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Creating and immediately setting the position of
+ particles failed and possibly crashed with GPU acceleration enabled. 
+This would only happen after one or more simulation updates.</li>
+                    <li>Creating many spread out particles might have crashed the GPU pipeline.</li>
+                </ul>
+            </ul>
+
+            <h3>Broad Phase</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>The SDK now supports multiple broad-phase 
+algorithms (SAP &amp; MBP). See Release Highlights, PxBroadPhaseType and
+ PxBroadPhaseDesc.</li>
+                    <li>PxVisualizationParameter::eMBP_REGIONS has been added to visualize MBP regions</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>The sap broadphase now gracefully handles 
+PxShape instances whose axis-aligned bounding boxes have min/max limits 
+with value  +/- PX_MAX_F32 or QNAN or INF. Such bounds values can occur 
+if a PxShape is given a global transform that is either illegal or close
+ to the upper limit of the floating point range. Prior to this release, 
+the sap broadphase could crash when the axis-aligned bounds of shapes 
+had values that weren't within the floating point range.  This has now 
+been fixed.  The overlap pairs reported by the broadphase for bounds 
+with such values is undefined.</li>
+                </ul>
+            </ul>
+
+            <h3>Vehicles</h3>
+            <ul>
+                <li>Added:</li>
+                <ul>
+                    <li>Vehicles now support serialization. A 
+PxSerializationRegistry instance may be passed into PxInitVehicleSdk and
+ PxCloseVehicleSdk in order to enable support.</li>
+                    <li>Vehicle telemetry graphs can now be queried per 
+channel for the most recent value with the function 
+PxVehicleGraph::getLatestValue.</li>
+                    <li>New vehicle PxVehicleDriveNW type has been 
+introduced.  This class makes use of a new differential type 
+PxVehicleDifferentialNW, which allows specified wheels to be equally 
+coupled to the differential, and allows all for some or all of the N 
+wheels to be driven. </li>
+                    <li>Support for camber angles has been added to the PxVehicleSuspensionData class.</li>
+                    <li>Moment of inertia parameter has been added to 
+the PxVehicleEngineData class. Prior to this a value of 1.0 was assumed 
+internally.  A default value of 1.0 has been used in the constructor for
+ backwards compatability.</li>
+                    <li>Vehicle manual contains new section describing 
+the conversion of default vehicle parameter values from SI units to any 
+system of units with particular reference to the use of centimetres 
+instead of metres .</li>
+                    <li>The SI units of each parameter in PxVehicleComponents.h has been documented. </li>
+                    <li>Vehicle manual contains updated troubleshooting section.</li>
+                    <li>The requirements for disabled wheels 
+(PxVehicleWheelsSimData::disableWheel) have been documented to make it 
+clear that disabled wheels must be no longer associated with a PxShape, 
+must have zero rotation speed, and must be decoupled from the 
+differential.  This is also now discussed in the guide.</li>
+                    <li>Wheel raycasts documentation has been improved to clarify the start and end points of each raycast.</li>
+                    <li>Suspension line raycasts do not need to be 
+performed for each vehicle prior to update with PxVehicleUpdates.  This 
+feature is implemented with a boolean array passed as an extra function 
+argument to PxVehicleSuspensionRaycasts.  This feature is useful for 
+vehicles that require only low level of detail.</li>
+                    <li>The clutch model now supports two accuracy modes
+ (PxVehicleClutchAccuracyMode::eESTIMATE and 
+PxVehicleClutchAccuracyMode::eBEST_POSSIBLE).  If the estimate mode is 
+chosen the computational cost and accuracy of the clutch can be tuned 
+with PxVehicleClutchData::mEstimateIterations.</li>
+                    <li>PxVehicleSuspensionData now has a function 
+setMassAndPreserveNaturalFrequency.  This modifies the mass and 
+stiffness of the spring in a way that preserves the spring natural 
+frequency.</li>
+                    <li>A new helper function PxVehicleCopyDynamicsData 
+has been added that allows dynamics data such as engine rotation speed, 
+wheel rotation speed, gear etc to be copied from one vehicle to another 
+of the same type.  This is particularly useful if a vehicle has a number
+ of different versions where each represents a different level of 
+detail.</li>
+                    <li>A new function PxVehicleWheelsSimData::copy has 
+been added to allow per wheel dynamics data to be copied from one 
+vehicle to another.</li>
+                    <li>The vehicle manual contains a new section "Level
+ of Detail" describing the available options for vehicles that require 
+only a low level of detail.</li>
+                    <li>PxVehicleTireLoadFilterData now requires that mMinNormalisedLoad is greater than or equal to zero.</li>
+                    <li>PxVehicleTireLoadFilterData now has a new member
+ variable mMinFilteredNormalisedLoad.  This value describes the filtered
+ normalised load that occurs when the normalised is less than or equal 
+to mMinNormalisedLoad.</li>
+                    <li>PxVehicleWheelsSimData now has a new function 
+setMinLongSlipDenominator.  This can be used to tune stability issues 
+that can arise when the vehicle slows down in the absence of brake and 
+drive torques.</li>
+                    <li>A new section "PxVehicleAutoBoxData" has been added to the vehicle tuning guide to describe operation of the automatic gearbox.</li>
+                    <li>A new section "The Vehicle Under-steers Then 
+Over-steers" has been added to the vehicle troubleshooting guide to 
+describe steps to avoid twitchy handling on bumpy surfaces.</li>
+                    A new section "The Vehicle Never Goes Beyond First 
+Gear" has been added to the vehicle troubleshooting guide to describe a 
+common scenario that occurs when the automatic gearbox is given a 
+latency time that is shorter than the time taken to complete a gear 
+change.
+                    <li>A new section "The Vehicle Slows Down 
+Unnaturally" has been added to the vehicle troubleshooting guide to 
+describe the steps that can be taken to help the vehicle slow down more 
+smoothly.</li>
+                    <li>A number of vehicle snippets have been added.</li>
+                </ul>
+                <li>Changed:</li>
+                <ul>
+                    <li>Minor api change for consistency: 
+PxVehicleDrive4WWheelOrder has been introduced to replace the enum 
+beginning with PxVehicleDrive4W::eFRONT_LEFT_WHEEL.</li>
+                    <li>Minor api change for consistency: 
+PxVehicleDrive4WControl has been introduced to replace the enum 
+beginning with PxVehicleDrive4WControl::eANALOG_INPUT_ACCEL.</li>
+                    <li>Minor api change for consistency: 
+PxVehicleDriveTankWheelOrder has been introduced to replace the enum 
+beginning with PxVehicleDriveTankWheelOrder::eFRONT_LEFT.</li>
+                    <li>Minor api change for consistency: 
+PxVehicleDriveTankControl has been introduced to replace the enum 
+beginning with PxVehicleDriveTank::eANALOG_INPUT_ACCEL.</li>
+                    <li>Minor api change for consistency: 
+PxVehicleDriveTankControlModel has been introduced to replace the enum 
+beginning with PxVehicleDriveTank::eDRIVE_MODEL_STANDARD.</li>
+                    <li>Minor api change for consistency: PxVehicleTypes has been introduced to replace the enum beginning with eVEHICLE_TYPE_DRIVE4W.</li>
+                    <li>Minor api change for consistency: 
+PxVehicleWheelGraphChannel has been introduced to replace the enum 
+beginning with PxVehicleGraph::eCHANNEL_JOUNCE.</li>
+                    <li>Minor api change for consistency: 
+PxVehicleDriveGraphChannel has been introduced to replace the enum 
+beginning with PxVehicleGraph::eCHANNEL_ENGINE_REVS.</li>
+                    <li>Minor api change for consistency: 
+PxVehicleGraphType has been introduced to replace the enum beginning 
+with PxVehicleGraph::eGRAPH_TYPE_WHEEL.</li>
+                    <li>PxVehicleUpdates now checks in checked and debug
+ config that the wheel positioning of the driven wheels in a 
+PxVehicleDrive4W obey the wheel ordering specified in 
+PxVehicleDrive4WWheelOrder.  Vehicles that are back-to-front or 
+right-to-left are also allowed. A warning is issued if the check fails.</li>
+                    <li>PxVehicleUpdates now checks in checked and debug
+ config that the odd wheels of a PxVehicleDriveTank are either all to 
+the left or all to the right of their even-wheeled complement, as 
+specified in PxVehicleDriveTankWheelOrder.  A warning is issued if the 
+check fails.</li>
+                    <li>To improve api consistency the arguments of the 
+function PxVehicleDriveDynData::setAnalogInput(const PxReal analogVal, 
+const PxU32 type) have been swapped so that it is now of the form 
+PxVehicleDriveDynData::setAnalogInput(const PxU32 type, const PxReal 
+analogVal).</li>
+                    <li>Non-persistent wheel dynamics data (slip, 
+friction, suspension force, hit data etc) has been moved out of the 
+PxVehicleWheelsDynData class and is now recorded in a PxWheelQueryResult
+ buffer that is passed as a function argument to the PxVehicleUpdates 
+function.</li>
+                    <li>PxVehicleWheels::isInAir() has been replaced 
+with PxVehicleIsInAir(const PxVehicleWheelQueryResult&amp; 
+vehWheelQueryResults) to reflect the change to non-persistent data 
+storage.</li>
+                    <li>The origin of vehicles can now be shifted to 
+stay in sync when the origin of the underlying PxScene is shifted. See 
+PxVehicleShiftOrigin() for details.</li>
+                    <li>PxVehicleWheels::setWheelShapeMapping and 
+PxVehicleWheels::getWheelShapeMapping have been moved to 
+PxVehicleWheelsSimData::setWheelShapeMapping and 
+PxVehicleWheelsSimData::getWheelShapeMapping</li>
+                    <li>PxVehicleWheels::setSceneQueryFilterData and 
+PxVehicleWheels::getSceneQueryFilterData have been moved to 
+PxVehicleWheelsSimData::setSceneQueryFilterData and 
+PxVehicleWheelsSimData::getSceneQueryFilterData</li>
+                    <li>PxVehicle4WEnable3WTadpoleMode and 
+PxVehicle4WEnable3WDeltaMode now take an extra function argument: a 
+non-const reference to a PxVehicleWheelsDynData.</li>
+                    <li>The section "SI Units" in the vehicle guide has 
+been updated to include the new functon 
+PxVehicleWheelsSimData::setMinLongSlipDenominator.</li>
+                    <li>PxVehicleTireData::mCamberStiffness has been 
+replaced with PxVehicleTireData::mCamberStiffnessPerUnitGravity.  
+PxVehicleTireData::mCamberStiffnessPerUnitGravity should be set so that 
+it is equivalent to the old value of PxVehicleTireData::mCamberStiffness
+ divided by the magnitude of gravitational acceleration.</li>
+                    <li>PxVehicleComputeTireForceDefault has been 
+removed from the public vehicle api. Custom tire shaders that call 
+PxVehicleComputeTireForceDefault are best implemented by taking a copy 
+of PxVehicleComputeTireForceDefault and calling the copy instead.</li>
+                </ul>
+                <li>Fixed:</li>
+                <ul>
+                    <li>Sticky tire friction is now activated in the 
+tire's lateral direction at the tire force application point when the 
+velocity at the base of the tire has low longitudinal and low lateral 
+components. Longitudinal sticky tire friction is unaffected and is still
+ activated when the vehicle has low forward speed. This fixes a minor 
+bug where vehicles positioned on a slope perpendicular to the slope's 
+downwards direction can slowly drift down the slope.</li>
+                    <li>Bugs in the suspension force and tire load computation have been fixed that affected handling when the car was upside down.</li>
+                    <li>The tire load passed to the tire force computation is now clamped so that it never falls below zero.</li>
+                    <li>A bug in the tank damping forces has now been 
+fixed.  Tanks now slow down more aggressively from engine and wheel 
+damping forces.</li>
+                </ul>
+            </ul>
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.2.4</h1>
+
+            <h2 style="TEXT-ALIGN: center">April 2013</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.2.4</h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li><i>Note: PS3 platform specific changes can be found in the PS3 readme file.</i></li>
+                    <li>Fixed a bug which caused actors to return wrong world bounds if the bounds minimum was above 10000 on any axis.</li>
+                    <li>Reporting allocation names can now be enabled or
+ disabled (see PxFoundation::setReportAllocationNames). When enabled, 
+some platforms allocate memory through 'malloc'.</li>
+                    <li>eEXCEPTION_ON_STARTUP is removed from PxErrorCode and it is no longer needed.</li>
+                    <li>Added boilerplate.txt to the Tools folder. SpuShaderDump.exe and clang.exe require it.</li>
+                    <li>PxWindowsDelayLoadHook.h has been moved from Include/foundation/windows to Include/common/windows.</li>
+                    <li>PxScene::saveToDesc now reports the bounceThresholdVelocity value.</li>
+                    <li>Fixed a bug in PxDefaultSimulationFilterShader: 
+the value of the second filter constant in the collision filtering 
+equation was ignored and instead the value of the first filter constant 
+was used.</li>
+                    <li>Fixed a crash bug in PCM collision.</li>
+                </ul>
+
+
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>Forces applied to bodies (with 
+PxRigidBody::addForce) that go to sleep in the subsequent update now 
+have their applied forces cleared when the body is set to sleep to avoid
+ them being applied in a later update when the body is once more awake. 
+ This bug broke the rule that forces applied with PxRigidBody::addForce 
+do not persist beyond the next scene update.</li>
+                    <li>Jittering of small spheres &amp; capsules on very large triangles has been fixed.</li>
+                </ul>
+
+                <h4>Cooking</h4>
+                <ul>
+                    <li>PxCookingParams constructor is now marked as 
+deprecated. PxToleranceScale is needed for PxCookingParams in order to 
+perform additional triangle check during cooking. This triangle check 
+will trigger warning if too huge triangles are used. This check will 
+ensure better simulation stability.</li>
+                </ul>
+
+                <h4>Scene Queries</h4>
+                <ul>
+                    <li>Added PxScene::forceDynamicTreeRebuild() function to immediately rebuild the scene query structures.</li>
+                    <li>Accuracy in sphere/capsule-vs-triangle overlap and sweep tests has been improved.</li>
+                </ul>
+
+                <h4>Broad Phase</h4>
+                <ul>
+                    <li>Fixed assert in debug mode that wrongly asserted
+ when an overlap pair was removed with perfect equality between the min 
+of one bound and the max of the other along at least one axis.</li>
+                </ul>
+
+                <h4>Character controller</h4>
+                <ul>
+                    <li>PxControllerFilterCallback has been added, to make CCT-vs-CCT filtering more flexible.</li>
+                    <li>Fixed a bug where PxControllerBehaviorCallback was not called when a PxUserControllerHitReport was not defined.</li>
+                    <li>PxObstacle notifications has been added to handle touched obstacles.</li>
+                    <li>Touched PxObstacle has been replaced by touched ObstacleHandle.</li>
+                    <li>PxObstacleContext::getObstacleByHandle has been added.</li>
+                    <li>Touched actors scene is checked before ride on shape, to ensure valid touched shape.</li>
+                    <li>Touched shape scene query flag is checked before ride on shape, to ensure valid touched shape.</li>
+                    <li>Touched shape user CCT filtering is triggered before ride on shape, to ensure valid touched shape.</li>
+                    <li>Box &amp; capsule controllers' resize function now properly take the up direction into account</li>
+                </ul>
+
+                <h4>Vehicles</h4>
+                <ul>
+                    <li>Documented potential problem with 
+PxVehicleWheelsDynData::getTireDrivableSurfaceType() and 
+PxVehicleWheelsDynData::getTireDrivableSurfaceShape() whereby the 
+pointer returned may reference a PxShape or PxMaterial that has been 
+released in-between storing the pointer in PxVehicleUpdates and any 
+subsequent query.</li>
+                    <li>PxVehicleWheelsSimData::disableWheel has been documented in more detail.  PxVehicleWheelsSimData::enableWheel has been added.</li>
+                    <li>Fixed a bug where the denominator of the 
+longitudinal slip calculation didn't take into account the value of 
+PxTolerancesScale::length.  This will only have an impact if 
+PxTolerancesScale::length != 1.0f.</li>
+                    <li>Fixed a bug where the engine torque would be 
+incorrectly applied if PxTolerancesScale::length != 1.0f.  This will 
+only have an impact if PxTolerancesScale::length != 1.0f.</li>
+                </ul>
+
+                <h4>Particles</h4>
+                <ul>
+                    <li>Creating and immediately setting the position of
+ particles failed and possibly crashed with GPU acceleration enabled. 
+This would only happen after one or more simulation updates.</li>
+                </ul>
+
+            </blockquote>
+
+            <h2><br><a name="platforms324">Supported Platforms</a></h2>
+
+            <blockquote>
+                Unchanged from <a href="#platforms323"> from 3.2.3</a> except:
+                <h4>Development</h4>
+                <ul>
+                    <li>Upgraded to Xcode 4.6</li>
+                </ul>
+            </blockquote>
+
+            <h2><br><a name="knownissues324">Known Issues And Limitations</a></h2>
+
+            <blockquote>
+                Unchanged from <a href="#knownissues323"> from 3.2.3</a>.
+            </blockquote>
+            <br>
+
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.2.3</h1>
+
+            <h2 style="TEXT-ALIGN: center">November 2012</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.2.3</h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li><i>Note: PS3 platform specific changes can be found in the PS3 readme file.</i></li>
+                    <li>Quaternions passed through the API are now considered valid if their magnitude is between 0.99 and 1.01.</li>
+                    <li>Fixed crash when running out of memory on creation of a triangle mesh.</li>
+                    <li>For applications using floating point 
+exceptions, the SDK will now mask or avoid exceptions arising from 
+invalid floating point operations (inexact and underflow exceptions may 
+still be generated).</li>
+                    <li>Fixed a bug with recursive use of the PxScene read/write lock.</li>
+                    <li>Fixed a shutdown bug with very short lived threads on Linux platforms.</li>
+                    <li>PhysX version number in error messages now printed in hex for easier reading.</li>
+                    <li>Fixed memory barrier and prefetch implementation for all posix based platforms (android, ios, osx, linux).</li>
+                </ul>
+
+                <h4>Broad Phase</h4>
+                <ul>
+                    <li>Fixed a broad phase crash bug that occurred when deleting shapes with bounds very far from the origin.</li>
+                </ul>
+
+
+                <h4>Collision Detection</h4>
+                <ul>
+                    <li>Documentation of limits of PxShape counts has been added for affected platforms.</li>
+                    <li>Made kinematics interact better with CCD.</li>
+                    <li>Adding support for disabled contact response in 
+CCD by respecting the dominance setting.  In this case, CCD will emit 
+events but will not alter the motion of the bodies.</li>
+                    <li>Fixed potential crash in eENABLE_PCM codepath.</li>
+                </ul>
+
+
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>Fixed bug in force based contact reports. An 
+assert could occur when PxPairFlag::eNOTIFY_THRESHOLD_FORCE_PERSISTS was
+ set and PxPairFlag::eNOTIFY_THRESHOLD_FORCE_FOUND was not set.</li>
+                    <li>Twist Limit range is documented for revolute and D6 joints, and validated.</li>
+                    <li>Reduced the number of SDK allocations when using CCD.</li>
+                </ul>
+
+
+                <h4>Scene Queries</h4>
+                <ul>
+                    <li>Raycasts against heighfields now return correct actual mesh index, which can be used for getTriangle().</li>
+                    <li>Fixed bug that caused scene queries to miss hits
+ for static rigid bodies that got moved around (after having been added 
+to the scene).</li>
+                    <li>Fixed rebuilding the dynamic structure properly when used for static rigid bodies.</li>
+                    <li>Fixed a rare crash in heightfield raycast code.</li>
+                </ul>
+
+                <h4>Character controller</h4>
+                <ul>
+                    <li>A new runtime tessellation feature has been added, that can help reducing FPU accuracy issues in the sweep tests.</li>
+                </ul>
+
+                <h4>Convex hulls</h4>
+                <ul>
+                    <li>Zero-sized convex hull data double delete detection fix.</li>
+                </ul>
+
+                <h4>Vehicles</h4>
+                <ul>
+                    <li>Vehicles with rigid body actors that are asleep 
+and also have no acceleration or steer inputs are treated as though they
+ are asleep too; that is, they are bypassed completely in the 
+PxVehicleUpdates function.  Vehicles with sleeping rigid body actors but
+ with non-zero acceleration or steer inputs are processed as normal in 
+PxVehicleUpdates and will automatically have their rigid body actor 
+woken up.</li>
+                    <li>New function PxVehicleSetUpdateMode to allow 
+PxVehicleUpdates to select between applying accelerations to vehicle 
+rigid bodies or immediate updating of their velocity.</li>
+                </ul>
+
+                <h4>Particles</h4>
+                <ul>
+                    <li>Fixed a non-deterministic crash appearing with rigid bodies using CCD and gpu particles in the same scene.</li>
+                </ul>
+
+                <h4>Physx Visual Debugger</h4>
+                <ul>
+                    <li>Material release events are now correctly sent to PVD. </li>
+                </ul>
+
+                <h4>RepX</h4>
+                <ul>
+                    <li>Add more RepX class information in PhysXAPI document. </li>
+                </ul>
+
+            </blockquote>
+
+            <h2><br><a name="platforms323">Supported Platforms</a></h2>
+
+            <blockquote>
+                <h4>Runtime</h4>
+                <ul>
+                    <li>Apple iOS</li>
+                    <li>Apple Mac OS X</li>
+                    <li>Google Android (version 2.2 or later for SDK, 2.3 or later required for samples)</li>
+                    <li>Linux (tested on Ubuntu)</li>
+                    <li>Microsoft Windows XP or later (NVIDIA Driver ver 295.73 or later is required for GPU acceleration)</li>
+                    <li>Microsoft Windows RT (formerly known as Windows on ARM) (SDK only, no samples yet)</li>
+                    <li>Microsoft XBox 360</li>
+                    <li>Sony Playstation 3</li>
+                </ul>
+                <h4>Development</h4>
+                <ul>
+                    <li>Microsoft Windows XP or later</li>
+                    <li>Microsoft Visual Studio 2008, 2010</li>
+                    <li>Xcode 4.5</li>
+                </ul>
+            </blockquote>
+
+            <h2><br><a name="knownissues323">Known Issues And Limitations</a></h2>
+
+            <blockquote>
+                Unchanged from <a href="#knownissues322"> from 3.2.2</a>.
+            </blockquote>
+            <br>
+
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.2.2</h1>
+
+            <h2 style="TEXT-ALIGN: center">October 2012</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.2.2</h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li><i>Note: PS3 platform specific changes can be found in the PS3 readme file.</i></li>
+
+                    <li>Added Microsoft Windows RT (formerly known as Windows on ARM) support.</li>
+                    <li>Suspended Sony Playstation Vita support.</li>
+                    <li>PxScene now exposes methods to make multithreaded sharing of scenes easier, see PxSceneFlags::eREQUIRE_RW_LOCK for details.</li>
+                    <li>Enabled Win64 DEBUG build to use SIMD enabled code path.</li>
+                    <li>Fixed bug in quaternion to axis/angle routine which failed on negative w values.</li>
+                    <li>Fixed crash when using ConvX on a PxCollection with external references.</li>
+                    <li>Fixed a spurious overlapping read/write error report when using simulation call backs in checked builds.</li>
+                    <li>The bounce threshold velocity can be set at 
+run-time with PxScene::setBounceThresholdVelocity. Likewise, it can be 
+queried with PxScene::getBounceThresholdVelocity</li>
+                    <li>Fixed return value of Ps::atomicExchange for POSIX based platforms: Linux, Android, IOS and OSX</li>
+                    <li>PxGeometryQuery::computePenetration() has been added, to compute the Minimum Translational Distance between geometry objects.</li>
+                </ul>
+
+                <h4>Broad Phase</h4>
+                <ul>
+                    <li>Fixed a broad phase crash bug.</li>
+                </ul>
+
+                <h4>Collision Detection</h4>
+                <ul>
+                    <li>Collision detection now more robust when confronted with ill-conditioned scenarios.</li>
+                    <li>Fixed crash when SDK is unable to create more contact pairs.  Now a warning is emitted and the contacts are ignored.</li>
+                </ul>
+
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>Improved the numerical stability of articulations.</li>
+                    <li>The target pose of a kinematically controlled dynamic actor can now get extracted through PxRigidDynamic::getKinematicTarget().</li>
+                    <li>The new flag 
+PxRigidDynamicFlag::eUSE_KINEMATIC_TARGET_FOR_SCENE_QUERIES makes scene 
+queries use the target pose of a kinematically controlled dynamic actor 
+instead of the actual pose.</li>
+                    <li>Fixed PxConstraintFlag::eVISUALIZATION having no effect.</li>
+                    <li>Fixed bug that caused sleep/wake-up notification events to get lost.</li>
+                    <li>Fixed a bug where sleeping objects were not waking up properly.</li>
+                    <li>Fixed potential assert when switching a rigid body between kinematic and dynamic with contact reports enabled.</li>
+                    <li>Fixed a bug where CCD didn't consider the scaling transform for triangle meshes.</li>
+                    <li>Fixed a potential crash bug when 
+PxConstraintFlag::ePROJECTION gets raised after a joint (that connects 
+to other projecting joints) has been created.</li>
+                    <li>Fixed a bug that resulted in joint breakage being reported every frame for any broken joint</li>
+                    <li>Added PxArticulationDriveCache for applying an impulse to an entire articulation</li>
+                    <li>fixed various crash bugs when sleeping articulations were removed from the scene and re-added
+                    </li><li>
+                </li></ul>
+
+                <h4>GPU Physics</h4>
+                <ul>
+                    <li>Fixed a possible out of bounds array access in GPU particle collision code.</li>
+                    <li>Updated the GPU PhysX Visual Indicator to allow APEX to hook into it.</li>
+                    <li>Fixed sample particles crash when there is a cuda kernel error.</li>
+                    <li>Upgraded GPU tech to CUDA 4.2.</li>
+                </ul>
+
+                <h4>Scene Queries</h4>
+                <ul>
+                    <li>PxSceneQueryHit::faceIndex is now filled in for sweeps against convex meshes.</li>
+                    <li>Added support for sphere and capsule shaped heightfield overlap queries.</li>
+                    <li>Added an inflation parameter to all sweep 
+queries in PxGeometryQuery, PxBatchQuery, and PxScene.  This can be used
+ to maintain a minimum distance between objects when moving them using 
+sweeps.</li>
+                    <li>Made sure that raycast multiple will include the
+ closest triangle in the results even if the output cannot hold all the 
+triangles that are hit.</li>
+                    <li>Fixed swept sphere against capsule not properly testing for initial overlap.</li>
+                    <li>Fixed the normal vector returned from sweeps being sometimes negated.</li>
+                    <li>Fixed a scenario where raycasting could miss an actor after the user has moved it using setGlobalPose().</li>
+                    <li>Fixed swept convex against plane sometimes reporting false hits</li>
+                    <li>Fixed swept/overlap/raycast with convexes that don't have identity scale rotation.</li>
+                    <li>Fixed a culling bug for box-triangle mesh sweep.</li>
+                </ul>
+
+                <h4>Convex hulls</h4>
+                <ul>
+                    <li>Convex hull is rejected if it has less than 4 polygons.</li>
+                    <li>Additional convex hull check has been added to detect open volumes.</li>
+                </ul>
+
+                <h4>Triangle meshes</h4>
+                <ul>
+                    <li>Added triangle mesh flags for 16bit indices and adjacency information.</li>
+                    <li>Fixed adjacency information order for getTriangle with triangle meshes to respect the vertex order.</li>
+                </ul>
+
+                <h4>HeightFields</h4>
+                <ul>
+                    <li>Fixed bug where capsules would bounce as they roll across heightfield edges.</li>
+                    <li>Fixed bug where spheres would bounce as they roll across heightfield vertices.</li>
+                    <li>Added adjacency information for getTriangle with height fields.</li>
+                </ul>
+
+                <h4>Particles</h4>
+                <ul>
+                    <li>Fixed triangle mesh shapes with ePARTICLE_DRAIN colliding with particles.</li>
+                    <li>Fixed crash with GPU particles when a lot of grid cells get occupied and vacated within one time step.</li>
+                </ul>
+
+                <h4>Character Controller</h4>
+                <ul>
+                    <li>The PxControllerBehaviorFlag::eCCT_USER_DEFINED_RIDE flag has been added.</li>
+                    <li>Fixed character controller not walking up steps properly if they are not exactly 90 degrees vertical.</li>
+                    <li>Fixed a bug where the character controller was not able to move up slopes when using a small step offset setting.</li>
+                    <li>Fixed a bug where the character controller could rise off the ground when blocked by a step.</li>
+                    <li>Fixed a bug where the character controller could rise off the ground when hitting another character controller.</li>
+                    <li>Fixed a bug where releasing a shape of a 
+touching actor and then releasing the character controller would crash. 
+Releasing shapes of actors in touch may still lead to crashes in other 
+situations. PxController::invalidateCache() can be used to work around 
+these situations.</li>
+                </ul>
+                <h4> CCD </h4>
+                <ul>
+                    <li>Fixed culling bug in CCD sweeps with meshes with transforms that caused contacts to be missed </li>
+                </ul>
+
+                <h4>Vehicles</h4>
+                <ul>
+                    <li>The vehicle sdk used to make the assumption that
+ wheels 0 and 1 (the front wheels) of a PxVehicleDrive4W responded 
+positively to the input steering wheel angle, while wheels 2 and 3 (the 
+rear wheels) responded in the opposite direction to that of the input 
+steering wheel angle.  A consequence of this assumed behaviour was the 
+restriction that PxVehicleWheelData::mMaxSteer was limited to positive 
+values.  This restriction has now been relaxed with the caveat that 
+PxVehicleWheelData::mMaxSteer must be in range (-Pi/2, Pi/2).  It is now
+ possible to turn each wheel positively or negatively relative to the 
+input steering wheel angle by choosing positive or negative values for 
+PxVehicleWheelData::mMaxSteer.  Ackermann steer correction might result 
+in the front and rear wheels competing against each other if the rear 
+and front all steer in the same direction relative to the input steering
+ wheel angle. If this is the case it will be necessary to set the 
+Ackermann accuracy to zero.</li>
+                    <li>It is now possible to set the engine rotation 
+speed (PxVehicleDriveDynData::setEngineRotationSpeed), the rotation 
+speed of each wheel (PxVehicleWheelsDynData::setWheelRotationSpeed) and 
+the rotation angle of each wheel 
+(PxVehicleWheelsDynData::setWheelRotationAngle). The default values for 
+each of these properties remains zero.</li>
+                    <li>Wheel contact reporting has been improved with 
+the addition of a number of query functions to the 
+PxVehicleWheelsDynData class.  These are 
+getTireDrivableSurfaceContactPoint, getTireDrivableSurfaceContactNormal,
+ getTireLongitudinalDir, getTireLateralDir, getSuspensionForce, 
+getTireDrivableSurfaceShape.</li>
+                    <li>It is now possible to store a userData pointer 
+per wheel.  This allows, for example, each wheel to be associated with a
+ game object.  The relevant functions are 
+PxVehicleWheelsDynData::setUserData and 
+PxVehicleWheelsDynData::getUserData.</li>
+                    <li>The default behavior of 
+PxVehicleWheels::setWheelShapeMapping has changed. Previously, default 
+values were automatically assigned to each wheel at construction so that
+ the ith wheel was mapped to the ith body shape.  This, however, made 
+the assumption that there was a wheel shape for each wheel, which is not
+ always true.  As a consequence, the default value is now -1, meaning 
+any mapping between body shape and wheel has to be explictily made by 
+calling setWheelShapeMapping.</li>
+                    <li>It is now possible to query the mapping between wheel and body shape with PxVehicleWheels::getWheelShapeMapping.</li>
+                    <li>It is now possible to query the tire shader data
+ that has been applied to each wheel with 
+PxVehicleWheelsDynData::getTireForceShaderData.</li>
+                    <li>The helper function PxVehicleComputeSprungMasses
+ has been added to aid the setup of the suspension sprung masses from 
+the rigid body centre of mass and wheel center coordinates.</li>
+                    <li>The scene query filter data applied to the 
+suspension raycasts was previously taken from the filter data of the 
+associated body shape.  This makes the assumption of a body shape per 
+wheel, which is not always true.  As a consequence, the filter data must
+ be explictly set per wheel by calling 
+PxVehicleWheels::setSceneQueryFilterData.  The filter data can be 
+queried with PxVehicleWheels::getSceneQueryFilterData.</li>
+                    <li>Sub-stepping of the vehicle update can now be applied per vehicle with PxVehicleWheelsSimData::setSubStepCount.</li>
+                    <li>PxVehicleDrivableSurfaceToTireFrictionPairs has 
+been modified so that the dictionary of material pointers can be updated
+ without the necessity of further allocation.  The create function has 
+been replaced with separate allocate and setup functions.</li>
+                    <li>A new vehicle type PxVehicleNoDrive has been 
+added to provide a close approximation to backwards compatibility with 
+the api of the 2.8.x NxWheelShape.</li>
+                </ul>
+
+
+                <h4>Visual Remote Debugger</h4>
+                <ul>
+                    <li>Added PVD compatible profile zones for batched queries.</li>
+                    <li>Added the ability to capture and inspect scene queries in PVD.</li>
+                    <li>SDK will now flush the pvd connection stream immediately after cloth or cloth fabric is created or released.</li>
+                    <li>Fixed the PVD support for articulations.</li>
+                    <li>Fixed PVD rendering wrong constraint limits.</li>
+                </ul>
+
+
+                <h4>Documentation</h4>
+                <ul>
+                    <li>Wrong statement in PxRigidStatic::release() has 
+been corrected. Static rigid bodies do wake up touching dynamic rigid 
+bodies on release.</li>
+                    <li>Wrong statement in PxShape::setFlag() has been corrected. It is a valid operation to clear all flags.</li>
+                    <li>Retroactively added more detail about changes to 3.2.1 release notes below.</li>
+                </ul>
+            </blockquote>
+
+            <h2><br><a name="platforms322">Supported Platforms</a></h2>
+
+            <blockquote>
+                <h4>Runtime</h4>
+                <ul>
+                    <li>Apple iOS</li>
+                    <li>Apple Mac OS X</li>
+                    <li>Google Android (version 2.2 or later for SDK, 2.3 or later required for samples)</li>
+                    <li>Linux (tested on Ubuntu)</li>
+                    <li>Microsoft Windows XP or later (NVIDIA Driver ver 295.73 or later is required for GPU acceleration)</li>
+                    <li>Microsoft Windows RT (formerly known as Windows on ARM) (SDK only, no samples yet)</li>
+                    <li>Microsoft XBox 360</li>
+                    <li>Sony Playstation 3</li>
+                </ul>
+                <h4>Development</h4>
+                <ul>
+                    <li>Microsoft Windows XP or later</li>
+                    <li>Microsoft Visual Studio 2008, 2010</li>
+                    <li>Xcode 4.2</li>
+                </ul>
+            </blockquote>
+
+
+
+
+            <h2><br><a name="knownissues322">Known Issues And Limitations</a></h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li>Memory leaks might get reported when using the 
+debug versions of malloc and free together with the debug version of 
+PhysX on Microsoft Windows platforms with Visual Studio 2010. This is 
+caused by a bug in the Visual Studio 2010 runtime libraries. If such a 
+leak appears immediately after releasing PhysX and all its components, 
+please contact us for information about workarounds.</li>
+                    <li>Use of articulations may require an increase of 64K in the stack size for threads making API calls and engine worker threads</li>
+                </ul>
+            </blockquote>
+
+            <blockquote>
+                Please also see the previous lists <a href="#knownissues321"> from 3.2.1</a> and earlier.
+            </blockquote>
+
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.2.1</h1>
+
+            <h2 style="TEXT-ALIGN: center">June 2012</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.2.1</h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li><i>Note: PS3 platform specific changes can be found in the PS3 readme file.</i></li>
+                    <li>Added GRB hooks for APEX 1.2.1.</li>
+                    <li>Some incorrect usages of __restrict have been fixed.</li>
+                    <li>A crash when the user's code had FPU exceptions enabled has been fixed.</li>
+                    <li>A rare crash on Win64 has been fixed.</li>
+                    <li>Removed no longer needed RapidXML library from distribution.</li>
+                    <li>Binary serialization can now save the names of actors and shapes.</li>
+                    <li>Removed a RepXUtility.h reinterpret_cast compile warning that happened on some platforms.</li>
+                    <li>Fixed a spurious overlapping read/write error report when using simulation call backs in checked builds.</li>
+                    <li>Fixed a bug in PxBinaryConverter when processing PxConvexMesh and PxMaterial assets. </li>
+                    <li>Fixed bug in implementations of array accessors 
+(PxPhysics::getScenes(), GuMeshFactory::getTriangleMeshes(), 
+GuMeshFactory::getConvexMeshes(), GuMeshFactory::getHeightFields(), 
+PxAggregate::getActors(), PxScene::getAggregates(), 
+PxScene::getArticulations(), PxScene::getConstraints()  ) when 
+startIndex &gt; bufferSize.</li>
+                    <li>Reduced the number of libraries provided for 
+game consoles. The following core libraries are included in the PhysX3 
+library and are not available separately anymore: LowLevel, 
+LowLevelCloth, PhysX3Common, PhysXProfileSDK, PhysXVisualDebuggerSDK, 
+PvdRuntime, PxTask, SceneQuery, SimulationController.</li>
+                </ul>
+
+                <h4>Documentation</h4>
+                <ul>
+                    <li>Clarified documentation regarding use of eSEND_SLEEP_NOTIFIES flag.</li>
+                    <li>Clarified documentation regarding using different CRT libraries.</li>
+                    <li>Removed some confusing statements about meta data from the documentation.</li>
+                    <li>Updated PsPool, PsSort so they can use the user allocator.</li>
+                </ul>
+
+                <h4>Mesh Cooking</h4>
+                <ul>
+                    <li>A warning message about negative volumes in the convex mesh cooker could cause a crash.</li>
+                    <li>Fixed failure to create valid convex hull in cooking when using PxConvexFlag::eINFLATE_CONVEX.</li>
+                    <li>The convex mesh cooking has been made more robust and properly outputs some error messages that were previously missing.</li>
+                    <li>Fixed crash bug in x64 version of ClothEdgeQuadifier.</li>
+                    <li>Adjacency information option for TriangleMeshes.
+  This is controlled using the PxCookingParams::buildTriangleAdjacencies
+ flag, and returned if available by PxMeshQuery::getTriangle().</li>
+                </ul>
+
+                <h4>Broad Phase</h4>
+                <ul>
+                    <li>The sdk gracefully handles the case of more than
+ 65536 broadphase pairs and reports a warning that some contacts will be
+ dropped in the event that this limit is exceeded.  This affects all 
+platforms except win32/win64/linux/linux64, which support a maximum 
+number of 4294967296 pairs.</li>
+                </ul>
+
+                <h4>Collision Detection</h4>
+                <ul>
+                    <li>Fixed a memory corruption bug in heightfield code.</li>
+                    <li>Fixed a bug in sphere vs mesh contact generation that could result in bad normals.</li>
+                    <li>Added a flag to enable or disable contact caching, to permit users to make a performance vs memory tradeoff.</li>
+                    <li>Fixed a crash bug in ContactReport cleanup code.</li>
+                </ul>
+
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>The simultaneous raising of both the 
+PxShapeFlag::eSIMULATION_SHAPE and PxShapeFlag::eTRIGGER_SHAPE flags is 
+now explicitly forbidden by the sdk.  If any of the two is raised then 
+any attempt to raise the other is rejected by the sdk and an error is 
+passed to the error stream. </li>
+                </ul>
+
+                <h4>Articulations</h4>
+                <ul>
+                    <li>The API stubbed in 3.2.0 for applying an impulse to an entire articulation is now implemented.</li>
+                </ul>
+
+                <h4>GPU Physics</h4>
+                <ul>
+                    <li>Much more specific error messages for CUDA compute capability related failures.</li>
+                    <li>Added SM35 support for GK110 GPUs.</li>
+                    <li>The CUDA contexts provided by the gpu dispatcher can now be shared across scenes.</li>
+                    <li>Fixed a possible out of bounds array access in GPU particle collision code.</li>
+                </ul>
+
+
+                <h4>Scene Queries</h4>
+                <ul>
+                    <li>Resolved poor GJK sweep convergence.</li>
+                    <li>Batched queries accept sphere geometry for sweeps.</li>
+                    <li>Optimized performance of raycasts.</li>
+                    <li>An internal limit of 65536 objects in the scene-query subsytem has been lifted.</li>
+                    <li>Fixed a bug where raycasts that sliced through two adjoining heightfields did not return correct results.</li>
+                    <li>Fixed a crash bug in PxFindOverlapTriangleMeshUtil when doing a sphere overlap query against a heightfield.</li>
+                </ul>
+
+
+                <h4>Cloth</h4>
+                <ul>
+                    <li>PxCloth::setMotionConstraints() now works with NULL parameter.</li>
+                </ul>
+
+                <h4>Character Controller</h4>
+                <ul>
+                    <li>PhysX CCT code no longer sets PxShape::userData.  </li>
+                    <li>Intersection of pairs of CCTs now uses the 
+supplied filter data and the supplied callback prefilter.  The callback 
+postfilter is not yet hooked up.</li>
+                    <li>A bug has been fixed whereby the filterData was ignored in one of the scene queries initiated by the PhysX CCT code.</li>
+                    <li>Introduced a more automatic mechanism for 
+invelidating the character controller's scene cache.  As part of this, 
+PxController::reportSceneChanged() was replaced with 
+PxController::invalidateCache().</li>
+                    <li>Added helper functions 
+PxController::get/setFootPosition() to let user specify the bottom point
+ of the character controller, rather than the center.</li>
+                    <li>A new helper function, PxController::resize(), has been added to facilitate character controller resizing.</li>
+                    <li>PxControllerBehaviorFlag::eCCT_CAN_RIDE_ON_OBJECT is not the default behavior anymore.</li>
+                    <li>The slope limit is only observed when walking on
+ static convex meshes, static triangle meshes, static boxes and static 
+heightfields.  The slope limit is not observed when walking on dynamic 
+or kinematic rigid bodies or static capsules or static spheres.  This 
+partially fixes a bug where the slope limit was inadvertently considered
+ for shapes attached to dynamic rigid bodies and inadvertently ignored 
+for boxes attached to static shapes.</li>
+                </ul>
+
+                <h4>Vehicles</h4>
+                <ul>
+                    <li>The vehicle sdk now reports an error to the 
+error stream and exits from PxVehicleUpates if PxInitVehicleSdk has not 
+been called in advance.  This avoids a divide-by-zero error that can 
+arise if the vehicle sdk has not been initialised correctly.</li>
+                </ul>
+
+                <h4>Visual Debugger</h4>
+                <ul>
+                    <li>Releasing of cloth fabrics is reported to the VRD.</li>
+                    <li>Ext::Joint::setActors() call now reported to PVD.</li>
+                    <li>Fixed crash bug when removing an aggregate containing a PxArticulation, while PVD is running.</li>
+                </ul>
+            </blockquote>
+
+            <h2><br>Supported Platforms</h2>
+
+            <blockquote>
+                Unchanged from <a href="#platforms320"> from 3.2</a>.
+            </blockquote>
+
+            <h2><br><a name="knownissues321">Known Issues And Limitations</a></h2>
+
+            <blockquote>
+                Unchanged from <a href="#knownissues320"> from 3.2</a>.
+            </blockquote>
+
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.2</h1>
+
+            <h2 style="TEXT-ALIGN: center">December 2011</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.2</h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li>Three new sample applications:  
+SampleCharacterCloth (character with cloth cape and cloth flags), 
+SampleBridges (character controller walking on dynamic bridges and 
+moving platforms), SampleCustomGravity (character controller with 
+arbitrary up vector).</li>
+                    <li>On Windows, the PxFoundation instance is now a process wide singleton and part of the new PhysX3Common.dll library</li>
+                    <li>PxCreatePhysics() does not create a PxFoundation
+ instance any longer. The PxFoundation instance has to be created in 
+advance through PxCreateFoundation().</li>
+                    <li>Calls to PxCreatePhysics() are not valid anymore if a PxPhysics instance already exists.</li>
+                    <li>If profiling information should be sent to the 
+PhysX Visual Debugger, a PxProfileZoneManager instance has to be 
+provided when creating the PxPhysics instance.</li>
+                    <li>The version number constant 
+PX_PUBLIC_FOUNDATION_VERSION has been replaced with PX_PHYSICS_VERSION. 
+Both PxFoundation and PxPhysics use the same version number now.</li>
+                    <li>The API now distinguishes between input and output stream types.</li>
+                    <li>Added mechanism to reduce code size by not 
+linking optional components.  See PxCreateBasePhysics() and the 
+PxRegister*() functions.</li>
+                    <li>Added getConcreteTypeName() to API classes to provide run time type information.</li>
+                    <li>Added PxScene::getTimestamp() to retrieve the simulation counter.</li>
+                    <li>PxGetFoundation has been moved to PxGetFoundation.h</li>
+                    <li>Changed the functions 
+PxPhysics::releaseUserReferences(), releaseCollection(), addCollection()
+ and releaseCollected() to now take a reference rather than a pointer.</li>
+                    <li>The signature of PxCreatePhysics has changed:  
+The Foundation SDK instance must be passed in explicitly.  One can also 
+hook profiling information by passing a PxProfileZoneManager.</li>
+                    <li>Platform conversion for serialized data has been
+ moved from the ConvX command line tool to the PxBinaryConverter 
+interface in the cooking library</li>
+                    <li>contact data block allocation now provides statistics on usage and max usage</li>
+                    <li>On all platforms except PS3, contact data blocks can be progressively allocated</li>
+                    <li>PxExtensionVisualDebugger has been renamed to 
+PxVisualDebuggerExt, PxExtensionsConnectionType renamed to 
+PxVisualDebuggerConnectionFlag</li>
+                    <li>Default implementations of memory and file streams added in PxDefaultStreams.h</li>
+                    <li>Renamed PxPhysics::getMetaData() to ::PxGetSDKMetaData().</li>
+                    <li>Scene::simulate() now takes a memory block which is used for allocation of temporary data during simulation</li>
+                    <li>On Windows, CudaContextManagerDesc support 
+appGUID now. It only works on release build. If your application employs
+ PhysX modules that use CUDA you need to use a GUID so that patches for 
+new architectures can be released for your game.You can obtain a GUID 
+for your application from Nvidia.</li>
+                </ul>
+
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>Introduced a new contact generation mode, see 
+eENABLE_PCM.  Note that this is an experimental feature that still shows
+ simulation artifacts in some scenarios.</li>
+                    <li>Introduced two new friction simulation modes, see eENABLE_ONE_DIRECTIONAL_FRICTION and eENABLE_TWO_DIRECTIONAL_FRICTION.</li>
+                    <li>Introduced a new scene query flag 
+PxSceneQueryFlag::eINITIAL_OVERLAP_KEEP to control how initial overhaps 
+are treated in scene queries.</li>
+                    <li>Per-triangle materials have been implemented.</li>
+                    <li>Changes to material properties are automatically reflected in contact resolution.</li>
+                    <li>New helper methods to compute mass properties 
+for a dynamic rigid body taking per shape density/mass values into 
+account (see documentation on PxRigidBodyExt for details).</li>
+                    <li>A new set of methods for overlap, sweep and 
+raycast tests based on PxGeometry objects has been introduced. See 
+documentation on PxMeshQuery and PxGeometryQuery for details).</li>
+                    <li>
+                        The contact report API has changed (for details 
+see the documentation on PxSimulationEventCallback::onContact()). Among 
+the changes are:
+                        <ul>
+                            <li>Reports only get sent for shape pairs 
+which request them. Previously, reports were sent for an actor pair even
+ if the requested shape pair event was not triggered (for example 
+because other shapes of the same actors started colliding etc.)</li>
+                            <li>The following PxPairFlags have been 
+removed eNOTIFY_CONTACT_FORCES, eNOTIFY_CONTACT_FORCE_PER_POINT, 
+eNOTIFY_CONTACT_FEATURE_INDICES_PER_POINT. Forces and feature indices 
+are now always provided if applicable.</li>
+                            <li>It is much easier now to skip shape pairs or contact point information when traversing the contact report data.</li>
+                            <li>The memory footprint of contact reports has been reduced.</li>
+                        </ul>
+                    </li>
+                    <li>The members featureIndex0/1 of PxContactPoint have been renamed to internalFaceIndex0/1 for consistency.</li>
+                    <li>For trigger reports, the eNOTIFY_TOUCH_PERSISTS 
+event has been deprecated and will be removed in the next release. For 
+performance and flexibility reasons it is recommended to use 
+eNOTIFY_TOUCH_FOUND and eNOTIFY_TOUCH_LOST only and manage the 
+persistent state separately.</li>
+                    <li>Added PxConstraintVisualizer interface and code to visualize joint frames and limits.</li>
+                    <li>Improved PxBatchQuery API.</li>
+                    <li>PxPhysics::getProfileZoneManager() now returns a pointer rather than a reference.</li>
+                    <li>PxRigidDynamic::moveKinematic() has been renamed to setKinematicTarget() to underline its precise semantics.</li>
+                    <li>Added new function PxShape::getGeometry and class PxGeometryHolder to improve Geometry APIs.</li>
+                    <li>PxCreatePlane now takes a PxPlane equation as a 
+parameter. Note that the interpretation of the distance value is negated
+ relative to 3.1</li>
+                    <li>Added new actor creation helpers PxCloneStatic, PxCloneDynamic, PxScaleActor.</li>
+                    <li>Added new functions PxTransformFromSegment, PxTransformFromPlaneEquation to simplify creation of planes and capsules.</li>
+                    <li>added PxJoint::getConstraint() to access the underlying constraint object, from which the constraint force can be read</li>
+                    <li>
+                        Some methods of PxAggregate have been renamed for consistency or replaced for extended functionality.
+                        <ul>
+                            <li>getMaxSize() is now called getMaxNbActors().</li>
+                            <li>getCurrentSize() is now called getNbActors().</li>
+                            <li>getActor() has been replaced by getActors() which copies the actor pointers to a user buffer.</li>
+                        </ul>
+                    </li>
+                    <li>Added support for kinematic triangle meshes, planes and heighfields.</li>
+                </ul>
+
+                <h4>Scene queries</h4>
+                <ul>
+                    <li>Dynamic AABBTree has been set as the default dynamic pruning structure.</li>
+                </ul>
+
+                <h4>Particles</h4>
+                <ul>
+                    <li>Removed descriptors from particle API: The 
+properties maxParticles and 
+PxParticleBaseFlag::ePER_PARTICLE_REST_OFFSET need to be specified when 
+calling PxPhysics::createParticleSystem() and createParticleFluid(). All
+ other properties can be adjusted after creation through set methods.</li>
+                </ul>
+
+                <h4>Cloth</h4>
+                <ul>
+                    <li>Added convex collision shapes, see PxCloth::addCollisionConvex()</li>
+                    <li>Added friction support, see PxCloth::setFrictionCoefficient()</li>
+                    <li>Added angle based bending constraints, see PxClothPhaseSolverConfig::SolverType::eBENDING</li>
+                    <li>Added separation constraints, a spherical volume that particles should stay outside of, see PxCloth::setSeparationConstraints()</li>
+                    <li>Added drag, see PxCloth::setDragCoefficient()</li>
+                    <li>Added inertia scaling, controls how much movement due to PxCloth::setTargetPose() will affect the cloth</li>
+                    <li>Added support for setting particle previous positions, see PxCloth::setParticles()</li>
+                    <li>Added controls for scaling particle mass during 
+collision, this can help reduce edge stretching around joints on 
+characters, see PxCloth::setCollisionMassScale()</li>
+                    <li>Particle data is now copied asynchronously from the GPU after simulate (rather than on demand)</li>
+                    <li>Improved fabric layout, you can now share fabric data across multiple phases to reduce memory usage, see PxClothFabric</li>
+                    <li>Fixed bug in collision when capsules are tapered at a slope &gt; 1</li>
+                </ul>
+
+                <h4>Vehicles</h4>
+                <ul>
+                    <li>Added PxVehicleDriveTank, a vehicle class that enables tank behaviors.</li>
+                    <li>Support for vehicles with more than 4 wheels, see PxVehicleDrive4W, PxVehicleDriveTank.</li>
+                    <li>Significant refactor of vehicle api to allow further types of vehicle to be added.</li>
+                    <li>Americal English spelling used in vehicle api.</li>
+                    <li>PxVehicle4W replaced with PxVehicleDrive4W, PxVehicle4WSimulationData replaced with PxVehicleDriveSimData4W.</li>
+                    <li>Removal of scene query helper functions and 
+structs: PxVehicle4WSceneQueryData, PxVehicle4WSetUpSceneQuery, 
+PxWheelRaycastPreFilter, PxSetupDrivableShapeQueryFilterData, 
+PxSetupNonDrivableShapeQueryFilterData, 
+PxSetupVehicleShapeQueryFilterData. See SampleVehicle_SceneQuery.h for 
+their implementation in SampleVehicle.</li>
+                    <li>PxVehicle4WSimpleSetup and 
+PxCreateVehicle4WSimulationData have been removed and replaced with 
+default values in vehicle components, see PxVehicleComponents.h.</li>
+                    <li>PxVehicle4WTelemetryData has been replaced with 
+PxVehicleTelemetryData, a class that supports vehicles with any number 
+of wheels, see PxVehicleTelemetryData</li>
+                    <li>PxVehicleDrivableSurfaceType no longer stored in
+ PxMaterial::userData.  A hash table of PxMaterial pointers is instead 
+used to associate each PxMaterial with a PxVehicleDrivableSurfaceType, 
+see PxVehicleDrivableSurfaceToTireFrictionPairs.</li>
+                    <li>PxVehicleTyreData::mLongitudinalStiffness has 
+been replaced with 
+PxVehicleTireData::mLongitudinalStiffnessPerUnitGravity, see 
+PxVehicleTireData.</li>
+                    <li>Tire forces now computed from a shader to allow user-specified tire force functions, see PxVehicleTireForceCalculator.</li>
+                    <li>Added helper functions to quickly configure 3-wheeled cars, see PxVehicle4WEnable3WTadpoleMode, PxVehicle4WEnable3WDeltaMode.</li>
+                </ul>
+
+                <h4>Serialization</h4>
+                <ul>
+                    <li>Changed the functions 
+PxPhysics::releaseUserReferences(), releaseCollection(), addCollection()
+ and releaseCollected() to now take a reference rather than a pointer.</li>
+                    <li>Platform conversion for serialized data has been
+ moved from the ConvX command line tool to the PxBinaryConverter 
+interface in the cooking library.</li>
+                    <li>Changed some functions in RepXUtility.h and RepX.h to take a reference rather than a pointer.</li>
+                </ul>
+
+
+                <h4>What we removed:</h4>
+                <ul>
+                    <li>Deformables have been removed. Use the optimized
+ solution for clothing simulation instead (see documentation on PxCloth 
+for details).</li>
+                    <li>PxSweepCache was replaced with PxVolumeCache.</li>
+                    <li>PVD is no longer enabled in the release build.</li>
+                    <li>Removed anisotropic friction.</li>
+                    <li>Removed the CCD mode eSWEPT_CONTACT_PAIRS.</li>
+                    <li>PxActorDesc has been removed.</li>
+                    <li>The ConvX tool has been removed.</li>
+                    <li>Removed empty default implementations of 
+functions in PxSimulationEventCallback for consistency and because it 
+can create bugs in user code if function prototypes change between 
+releases.  Users must now supply (eventually blank) implementations for 
+all functions.</li>
+                    <li>Octree and quadtree pruning structures have been removed.</li>
+                </ul>
+
+                <h4>Fixed Bugs</h4>
+                <ul>
+                    <li>PxScene::getActors() might not work properly when the startIndex parameter is used.</li>
+                    <li>Improved the doc-comment of PxConvexMesh::getMassInformation().</li>
+                    <li>RepX instantiation can lose all internal references when addOriginalIdsToObjectMap is false.</li>
+                    <li>PxSetGroup crashed when used on a compound.</li>
+                    <li>PhysXCommon.dll can be delay loaded.</li>
+                    <li>ContactReportStream can now handle huge report numbers and size (resize-able flag) can be set in PxSceneDesc.h.</li>
+                    <li>Fixed assert in sweep tests.</li>
+                    <li>Concurrent read/write operations during a 
+PxScene::fetchResults() call were not detected properly and no warning 
+message got sent in checked builds. Forbidden write operations during 
+callbacks triggered by PxScene::fetchResults() (contact/trigger reports 
+etc.) were not covered either.</li>
+                    <li>Fixed crash bug that occurred during collision 
+detection when more than 16K of contact data was generated.  Contacts 
+that generate more than 16K of contact data are now fully supported.</li>
+                    <li>Fixed crash bug when PhysX Visual Debugger is 
+connected and an object gets modified and then released while the 
+simulation is running.</li>
+                </ul>
+
+            </blockquote>
+
+            <h2><br><a name="platforms320">Supported Platforms</a></h2>
+
+            <blockquote>
+                <h4>Runtime</h4>
+                <ul>
+                    <li>Apple iOS</li>
+                    <li>Apple Mac OS X</li>
+                    <li>Google Android (version 2.2 or later for SDK, 2.3 or later required for samples)</li>
+                    <li>Linux (tested on Ubuntu)</li>
+                    <li>Microsoft Windows XP or later (NVIDIA Driver ver 295.73 or later is required for GPU acceleration)</li>
+                    <li>Microsoft XBox 360</li>
+                    <li>Sony Playstation 3</li>
+                    <li>Sony Playstation Vita</li>
+                </ul>
+                <h4>Development</h4>
+                <ul>
+                    <li>Microsoft Windows XP or later</li>
+                    <li>Microsoft Visual Studio 2008, 2010</li>
+                    <li>Xcode 4.2</li>
+                </ul>
+            </blockquote>
+
+            <h2><br><a name="knownissues320">Known Issues And Limitations</a></h2>
+
+            <blockquote>
+
+                <h4>Binary Serialization</h4>
+                <ul>
+                    <li>Meta data generation for PxParticleFluid and PxParticleSystem serializables currently fails.</li>
+                    <li>For collections that contain jointed rigid 
+bodies all corresponding joints need to be added as well, otherwise 
+deserialization will fail.
+                </li></ul>
+                <h4>Rigid Body Simulation</h4>
+                <ul>
+                    <li>Capsules and spheres can struggle to come to 
+rest on even perfectly flat surfaces. To ensure these objects come to 
+rest, it is necessary to increase angular damping on rigid bodies made 
+of these shapes. In addition, flagging the capsule/sphere's material 
+with physx::PxMaterialFlag::eDISABLE_STRONG_FRICTION can help bring 
+these shapes to rest.</li>
+                </ul>
+                <h4>Character Cloth Sample</h4>
+                <ul>
+                    <li>An NVIDIA GPU with Compute Capability 2.0 or 
+higher is required for GPU accelerated simulation in the 
+SampleCharacterCloth sample, if no such device is present then 
+simulation will be performed on the CPU.</li>
+                    <li>Note that this is not a general SDK requirement,
+ the clothing SDK supports cards with Compute Capability &lt; 2.0 but 
+with limitations on mesh size.</li>
+                </ul>
+                <h4>Character Controller</h4>
+                <ul>
+                    <li>Releasing shapes of actors that are in touch 
+with a character controller may lead to crashes. Releasing whole actors 
+doesn't lead to the same problems. PxController::invalidateCache() can 
+be used to work around these issues.</li>
+                </ul>
+
+            </blockquote>
+
+            <blockquote>
+                Please also see the previous lists <a href="#knownissues311"> from 3.1.1</a> and earlier.
+            </blockquote>
+
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.1.2</h1>
+
+            <h2 style="TEXT-ALIGN: center">December 2011</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.1.2</h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li>Fixed wrong write/read clash checks.</li>
+                    <li>Removed some compiler warnings from public header files.</li>
+                    <li>Fixed PxScene::getActors() returning wrong actors when a start index is specified.</li>
+                </ul>
+
+
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>Fixed broken joint projection in connection with kinematics.</li>
+                    <li>Fixed inaccurate normals returned from height field scene queries.</li>
+                    <li>Fixed a crash when the geometry of a shape 
+changes and then the actor gets removed from the scene while the 
+simulation is running.</li>
+                    <li>Fixed a crash when re-adding scene-query shape actors to scene.</li>
+                </ul>
+
+
+                <h4>Particles</h4>
+                <ul>
+                    <li>Fixed crash bug in particle simulation code on GPU.</li>
+                </ul>
+
+
+                <h4>Cloth</h4>
+                <ul>
+                    <li>Fixed a crash when GPU fabrics are shared between cloths.</li>
+                    <li>Fixed a hang in cloth fiber cooker when handed non-manifold geometry.</li>
+                </ul>
+
+                <h4>Samples</h4>
+                <ul>
+                    <li>Fixed SampleVehicles doing an invalid write.</li>
+                    <li>Fixed SampleVehicle jitter in profile build.</li>
+                </ul>
+
+            </blockquote>
+
+            <h2><br>Supported Platforms (available in separate packages)</h2>
+
+            <blockquote>
+                Unchanged from <a href="#platforms311"> from 3.1.1</a>.
+            </blockquote>
+
+            <h2><br>Known Issues And Limitations</h2>
+
+            <blockquote>
+                Unchanged from <a href="#knownissues310"> from 3.1</a>.
+            </blockquote>
+
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.1.1</h1>
+
+            <h2 style="TEXT-ALIGN: center">November 2011</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.1.1</h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li>Ported samples to Linux.</li>
+                    <li>Fixed crash bug in ConvX.</li>
+                    <li>Fixed crash bug in the allocator code of PXC_NP_MEM_BLOCK_EXTENSIBLE.</li>
+                    <li>Fixed crash bug when connected to PVD on various platforms.</li>
+                    <li>Fixed bogus asserts due to overly strict validation of quaternions.</li>
+                    <li>Fixed one frame lag in PVD scene statistics.</li>
+                    <li>Fixed a number of OSX PVD sockets issues.</li>
+                    <li>Fixed SampleSubmarine code that violated concurrent read/writes restriction.</li>
+                    <li>Added warnings about read/write hazards to the checked build.</li>
+                    <li>Fixed RepX not reading joint properties.</li>
+                    <li>Fixed support for concurrent scene queries.</li>
+                    <li>Fixed PhysX GPU Visual Indicator support.</li>
+                    <li>Made it more clear in documentation that simulate(0) is not allowed.</li>
+                </ul>
+
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>eNOTIFY_TOUCH_LOST trigger events do now get 
+reported if one of the objects in contact gets deleted (see 
+documentation of PxTriggerPair for details).</li>
+                    <li>Dynamic rigid bodies with trigger shapes only do not wake up other touching bodies anymore.</li>
+                    <li>Added lost touch events for trigger reports when objects get deleted.</li>
+                    <li>Fixed dynamic triggers waking up actors they are triggered by.</li>
+                    <li>Removed an inapropriate assert from articulation code.</li>
+                    <li>Fixed problem with the angular momentum conservation of articulations.</li>
+                    <li>Fixed articulation sleep problems.</li>
+                    <li>Fixed a linear velocity related bug in CCD.</li>
+                    <li>Fixed crash bug CCD.</li>
+                    <li>Optimized performance of joint information being sent to PVD.</li>
+                </ul>
+
+            </blockquote>
+
+            <h2><br><a name="platforms311">Supported Platforms (available in separate packages)</a></h2>
+
+            <blockquote>
+                <h4>Runtime</h4>
+                <ul>
+                    <li>Microsoft Windows XP or later</li>
+                    <li>Microsoft XBox 360</li>
+                    <li>Sony Playstation 3</li>
+                    <li>Android 2.2 or later for SDK, 2.3 or later required for samples</li>
+                    <li>Linux (tested on Ubuntu)</li>
+                    <li>Mac OS X</li>
+                </ul>
+                <h4>Development</h4>
+                <ul>
+                    <li>Microsoft Windows XP or later</li>
+                    <li>Microsoft Visual Studio 2008, 2010</li>
+                    <li>Xcode 3</li>
+                </ul>
+            </blockquote>
+
+            <h2><br><a name="knownissues311">Known Issues And Limitations</a></h2>
+
+            <blockquote>
+                Unchanged from <a href="#knownissues310"> from 3.1</a>.
+            </blockquote>
+
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.1</h1>
+
+            <h2 style="TEXT-ALIGN: center">September 2011</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.1</h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li>VC10 support has been introduced.</li>
+                    <li>VC8 support has been discontinued.</li>
+                    <li>Namespaces cleaned up.</li>
+                    <li>Extensions, Character Controller and Vehicle source code made available in binary distribution.</li>
+                    <li>Added x86,x64 suffix to PxTaskCUDA.dll</li>
+                    <li>Removed boolean return value from PxScene::addActor(...), and similar API calls.</li>
+                    <li>Added MacOS, Android and Linux to the list of supported platforms.  See Supported Platforms below for details.</li>
+                    <li>Upgraded GPU tech to CUDA 4.</li>
+                    <li>Cleaned up a large number of warnings at C++ warning level 4, and set SDK to compile with warnings as errors.</li>
+                    <li>Removed individual sample executables in favor of one Samples executable from PC and console builds.</li>
+                    <li>Fixed alpha blending in samples.</li>
+                    <li>Simplified some code in samples.</li>
+                    <li>Improved ambient lighting in samples.</li>
+                    <li>Made samples work with older graphics cards.</li>
+                    <li>Improved and added more content the user's guide.</li>
+                    <li>No longer passing NULL pointers to user allocator to deallocate.</li>
+                    <li>Various improvements to Foundation and classes shared with APEX.</li>
+                </ul>
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>Rigid Body: High performance alternative convex 
+narrow phase code available to source licensees. See 
+PERSISTENT_CONTACT_MANIFOLD in the code.</li>
+                    <li>Significant advancements in the continuous collision detection algorithm.</li>
+                    <li>Optimizations and robustness improvements for articulations.</li>
+                    <li>Added some helper code to the API.</li>
+                    <li>Added sleep code for articulations.</li>
+                    <li>Added support for vehicles with more than one chassis shape.</li>
+                    <li>Solver iteration count for articulations.</li>
+                    <li>Articulation limit padding configurable.</li>
+                    <li>The reference count of meshes does now take the 
+application's reference into acount as well and thus has increased by 1 
+(it used to count the number of objects referencing the mesh only). Note
+ that a mesh does only get destroyed and removed from the list of meshes
+ once the reference count reaches 0.</li>
+                    <li>Fixed autowake parameter sometimes being ignored.</li>
+                    <li>Constraint solver optimizations.</li>
+                    <li>Improved behavior of character controller on steep slopes.</li>
+                    <li>Binary serialization now saves names.</li>
+                    <li>Removed some descriptors from API.</li>
+                    <li>Removed the angular velocity term in the joint positional drive error formula.</li>
+                    <li>Fixed bug in capsule sweep versus mesh.</li>
+                    <li>Fixed a crash bug in the tire model.</li>
+                    <li>Fixed crashing of single link articulations.</li>
+                    <li>Fixed bug related to removing elements of an aggregate.</li>
+                    <li>Fixed swapped wheel graphs in sample vehicle.</li>
+                    <li>Fixed some slow moving bodies falling asleep in midair.</li>
+                    <li>Fixed missing collisions after a call to resetFiltering.</li>
+                    <li>Fixed broken autowake option in setAngularVelocity.</li>
+                    <li>Fixed D6 joint linear limits being uninitialized.</li>
+                    <li>A large number of misc. bug fixes and optimizations.</li>
+                    <li>Improved documentation and error messages associated with running out of narrow phase buffer blocks.</li>
+                    <li>Added articulation documentation.</li>
+                    <li>Expanded manual sections on joints.</li>
+                    <li>Improved reference doc for PxSceneQueryHitType.</li>
+                    <li>Added reference doc for PxSerializable.</li>
+                </ul>
+
+                <h4>Particles</h4>
+                <ul>
+                    <li>Particle index allocation removed from SDK. Added index allocation pool to extensions.</li>
+                    <li>Replaced GPU specific side band API PxPhysicsGpu and PxPhysics::getPhysicsGpu() with PxParticleGpu.</li>
+                    <li>
+                        Memory optimizations on all platforms and 
+options to reduce memory usage according to use case with new per 
+particle system flags:
+                        <ul>
+                            <li>PxParticleBaseFlag::eCOLLISION_WITH_DYNAMIC_ACTORS</li>
+                            <li>PxParticleBaseFlag::ePER_PARTICLE_COLLISION_CACHE_HINT</li>
+                        </ul>
+                    </li>
+                    <li>Fixed rare crash appearing with multi-threaded non-GPU particle systems and rigid bodies.</li>
+                    <li>Fixed particles leaking through triangle mesh geometry on GPU.</li>
+                    <li>Fixed fast particles tunneling through scene geometry in some cases.</li>
+                    <li>Fixed erroneous collision of particles with teleporting rigid shapes (setGlobalPose).</li>
+                    <li>Fixed particle sample behavior with some older GPU models.</li>
+                    <li>Fixed a GPU particle crash bug.</li>
+                </ul>
+
+
+                <h4>Cloth</h4>
+                <ul>
+                    <li>A new solution for simulating cloth and clothing.</li>
+                </ul>
+
+
+                <h4>Deformables</h4>
+                <ul>
+                    <li>Deformables are deprecated and will be removed 
+in the next release. There is a new optimized solution for clothing 
+simulation (see documentation on PxCloth for details).</li>
+                </ul>
+            </blockquote>
+
+            <h2><br>Supported Platforms (available in separate packages)</h2>
+
+            <blockquote>
+                <h4>Runtime</h4>
+                <ul>
+                    <li>Microsoft Windows XP or later</li>
+                    <li>Microsoft XBox 360</li>
+                    <li>Sony Playstation 3</li>
+                    <li>Android 2.2 or later for SDK, 2.3 or later required for samples</li>
+                    <li>Linux (SDK tested on Ubuntu, samples not yet ported) </li>
+                    <li>Mac OS X</li>
+                </ul>
+                <h4>Development</h4>
+                <ul>
+                    <li>Microsoft Windows XP or later</li>
+                    <li>Microsoft Visual Studio 2008, 2010</li>
+                    <li>Xcode 3</li>
+                </ul>
+            </blockquote>
+
+            <h2><br><a name="knownissues310">Known Issues And Limitations</a></h2>
+
+            <blockquote>
+                <h4>General</h4>
+                <ul>
+                    <li>Under VC10, you may get warnings due to 
+conflicting build configuration flags.  Workaround: Clear the "Inherit 
+from parent or project defaults" flag for all projects in 
+Project-&gt;Properties-&gt;C/C++-&gt;Command Line.  We plan to fix this 
+for the 3.1 general availability release.</li>
+                </ul>
+                <h4>Scene Query</h4>
+                <ul>
+                    <li>Querying the scene (e.g. using raycastSingle()) from multiple threads simultaneously is not safe.</li>
+                </ul>
+                <h4>Cloth</h4>
+                <ul>
+                    <li>Even simple parameters of a PxCloth can not be set or accessed while the simulation is running.</li>
+                </ul>
+                <h4>RepX</h4>
+                <ul>
+                    <li>RepX fails to load elements of aggregate joint parameters (PxD6JointDrive etc.)</li>
+                </ul>
+            </blockquote>
+
+            <blockquote>
+                Please also see the previous lists <a href="#knownissues300"> from 3.0</a>.
+            </blockquote>
+
+
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+            <br>
+            <!-- -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
+
+
+            <h1 style="TEXT-ALIGN: center">Release Notes - NVIDIA<sup>®</sup> PhysX<sup>®</sup> SDK 3.0</h1>
+
+            <h2 style="TEXT-ALIGN: center">February 14<sup>th</sup>2011</h2>
+
+            <h2>What's New In NVIDIA PhysX 3.0</h2>
+
+            <blockquote>
+                <h4>General</h4>
+
+                This third major version of the SDK is a significant 
+rewrite of the entire technology.  We did away with a large amount of 
+legacy clutter and replaced them with a wealth of new features and 
+improvements.
+                Because even the API changes are so significant, it is 
+easier to see it as a whole new product rather than a long list of 
+changes.
+
+                <h4>What we removed:</h4>
+                <ul>
+                    <li>The dedicated NVIDIA PhysX PPU hardware is not supported any more.</li>
+                    <li>Scene compartments are not supported anymore. All created physical objects are now part of one and the same compartment.</li>
+                    <li>Force fields are not part of the NVIDIA PhysX SDK anymore.</li>
+                    <li>Splitting a simulation timestep into multiple 
+substeps is not a functionality of the NVIDIA PhysX SDK any longer and 
+has to be implemented above the SDK.</li>
+                </ul>
+
+                <h4>Key new features:</h4>
+                <ul>
+                    <li>Articulations: A way to create very stiff joint assemblies.</li>
+                    <li>Serialization: Save objects in a binary format and load them back quickly!</li>
+                    <li>Broad Phase Clustering: Put objects that belong together into a single broadphase volume.</li>
+                    <li>Driverless Model: No need to worry about system software on PC anymore.</li>
+                    <li>Dynamic Character Controller: A character controller that can robustly walk on dynamic objects.</li>
+                    <li>Vehicle Library: A toolkit to make vehicles, including an all new tire model.</li>
+                    <li>Non-Simulation Objects: A staging are outside of the simulation from where you can add things into the simulation at high speed.</li>
+                    <li>Simulation Task Manager: Take control of the management of simulation tasks.</li>
+                    <li>Stable Depenetration: Large penetrations can be gracefully recovered from.</li>
+                    <li>Double Buffering: You can read from and write to the simulated objects while the simulation is running on another thread.</li>
+                    <li>Mesh Scaling: Create different nonuniformly scaled instances of your meshes and convexes without duplicating the memory.</li>
+                    <li>Distance Based Collision Detection: Have the 
+simulation create contacts before objects touch, and do away with 
+unsightly overlaps.</li>
+                    <li>Fast Continuous Collision Detection: Have small and high speed objects collide correctly without sacrificing performance.</li>
+                    <li>Significantly increased performance and memory footprint, especially on consoles.</li>
+                    <li>Unified solver for deformables and rigid bodies for great interaction.</li>
+                    <li>Triangle collision detection with deformables.</li>
+                    <li>Support for our new Physics Visual Debugger, including integrated profiling.</li>
+                </ul>
+
+
+                <h4>Math classes</h4>
+                <ul>
+                    <li>Matrix based transforms have been replaced by quaternions.</li>
+                    <li>
+                        All angles are now expressed in radians. IN 
+PARTICULAR the PxQuat constructor from
+                        axis and angle as well as the getAngleAxis and 
+fromAngleAxis methods now use radians rather than degrees.
+                    </li>
+                </ul>
+
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>Capsules are now defined to extend along the x rather than the y axis.</li>
+                    <li>Triangle meshes do not support heightfield functionality anymore. Use the dedicated PxHeightField class instead.</li>
+                    <li>Dynamic triangle mesh actors are not supported 
+any longer. However, you can decompose your mesh into convex parts and 
+create a dynamic actor consisting of these convex parts.</li>
+                    <li>The deprecated heightfield property 
+NxHeightFieldDesc::verticalExtent is not supported any longer. Please 
+use the PxHeightFieldDesc::thickness parameter instead.</li>
+                    <li>NxSpringAndDamperEffector is not supported anymore. Use PxDistanceJoint instead.</li>
+                    <li>Joints are now part of the PhysX extensions library (PhysXExtensions).</li>
+                    <li>Wheel shapes have been replaced by the more 
+flexible entity PxWheel. A default wheel implementation, encapsulating 
+most of the old wheel functionality, can be found in the PhysX 
+extensions library (see PxDefaultWheel).</li>
+                    <li>The NxUtilLib library has been removed. 
+Sweep/overlap/raycast tests and other helper methods can be found in the
+ new GeomUtils library.</li>
+                    <li>Materials can no longer be accessed through 
+indices. Per triangle material meshes need a material table which can be
+ specified per shape (see PxShape::setMaterials() for details).</li>
+                    <li>The default material is not available anymore.</li>
+                </ul>
+
+                <h4>Particle Systems, Particle Fluids</h4>
+                <ul>
+                    <li>
+                        The NxFluid class has been replaced with two classes for separation of functionality and ease of use.
+                        <ul>
+                            <li>PxParticleSystem: Particles colliding against the scene.</li>
+                            <li>PxParticleFluid: Particles simulating a fluid (sph).</li>
+                        </ul>
+                    </li>
+                    <li>
+                        Simplified parameterization for particle systems.
+                        <ul>
+                            <li>Using absolute distances instead of relative multipliers to rest spacing</li>
+                            <li>Simplified sph parameters</li>
+                            <li>Unified collision parameters with deformable and rigid body features</li>
+                        </ul>
+                    </li>
+                    <li>
+                        Creating and releasing particles is now fully controlled by the application.
+                        <ul>
+                            <li>Particle lifetime management isn't provided through the SDK anymore.</li>
+                            <li>Emitters have been removed from the SDK.</li>
+                            <li>Drain shapes don't cause particles to be deleted directly, but to be flagged instead.</li>
+                            <li>Initial particle creation from the particle system descriptor isn't supported anymore.</li>
+                        </ul>
+                    </li>
+                    <li>Particle data buffer handling has been moved to the SDK.</li>
+                    <li>Per particle collision rest offset.</li>
+                    <li>
+                        GPU accelerated particle systems.
+                        <ul>
+                            <li>Application controllable mesh mirroring to device memory.</li>
+                            <li>Runtime switching between software and GPU accelerated implementation.</li>
+                        </ul>
+                    </li>
+                </ul>
+            </blockquote>
+
+            <h2><br>Supported Platforms (available in separate packages)</h2>
+
+            <blockquote>
+                <h4>Runtime</h4>
+                <ul>
+                    <li>Microsoft Windows XP or and later</li>
+                    <li>Microsoft XBox360</li>
+                    <li>Sony Playstation 3</li>
+                </ul>
+                <h4>Development</h4>
+                <ul>
+                    <li>Microsoft Windows XP or and later</li>
+                    <li>Microsoft Visual Studio 2008</li>
+                </ul>
+            </blockquote>
+
+            <h2><br><a name="knownissues300">Known Issues And Limitations</a></h2>
+
+            <blockquote>
+                <h4>Rigid Bodies</h4>
+                <ul>
+                    <li>Adding or removing a PxAggregate object to the scene is not possible while the simulation is running.</li>
+                </ul>
+                <h4>Particle Systems</h4>
+                <ul>
+                    <li>
+                        Releasing the Physics SDK may result in a crash when using GPU accelerated particle systems. <br>
+                        This can be avoided by doing the following before releasing the Physics SDK:
+                        <ul>
+                            <li>Releasing the PxScene objects that contain the GPU accelerated particle systems.</li>
+                            <li>Releasing application mirrored meshes by
+ calling PxPhysicsGpu::releaseTriangleMeshMirror(...), 
+PxPhysicsGpu::releaseHeightFieldMirror(...) or 
+PxPhysicsGpu::releaseConvexMeshMirror(...).</li>
+                        </ul>
+                    </li>
+                </ul>
+            </blockquote>
+
+            <p>
+                <br>
+                Copyright (C) 2008-2019 NVIDIA Corporation, 2701 San 
+Thomas Expressway, Santa Clara, CA 95050 U.S.A. All rights reserved. <a href="http://www.nvidia.com/">www.nvidia.com</a>
+            </p>
+
+
+</blockquote></body></html>


### PR DESCRIPTION
Binaries have been built for: win32, win64, uwp32, uwp64, uwparm32, uwparm64